### PR TITLE
Allow plotting of blocked rays (rays that don't make it to the end detector)

### DIFF
--- a/docs/user-guide.ipynb
+++ b/docs/user-guide.ipynb
@@ -218,7 +218,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model.plot(max_rays=10000)"
+    "model.plot(max_rays=5000)"
    ]
   },
   {
@@ -228,7 +228,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "detectors[0].plot()"
+    "detectors[0].tofs.visible.plot()"
    ]
   },
   {
@@ -238,7 +238,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "choppers[2].plot()"
+    "choppers[3].tofs.plot()"
    ]
   },
   {
@@ -248,7 +248,10 @@
    "source": [
     "### Data inspection\n",
     "\n",
-    "It is also possible to inspect the data by using the `.tofs` and `.wavelengths` properties."
+    "The `.tofs` and `.wavelengths` methods of the beamline components return a proxy object,\n",
+    "which gives access to the data they hold.\n",
+    "\n",
+    "Accessing the `.data` returns a data group with both visible and blocked neutrons:"
    ]
   },
   {
@@ -258,17 +261,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "detectors[1].tofs"
+    "detectors[1].tofs.data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee85b045-19f6-448a-ac0d-73ee75690a72",
+   "metadata": {},
+   "source": [
+    "To inspect individual components, one can for example use the `.data` property of the `.visible` accessor"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "927e0aa4-80a7-41f4-8715-de5ab3c40d22",
+   "id": "a8cb6b72-f98c-4497-8872-941b0fd19a0b",
    "metadata": {},
    "outputs": [],
    "source": [
-    "detectors[1].wavelengths"
+    "detectors[1].tofs.visible.data"
    ]
   },
   {
@@ -286,7 +297,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "detectors[1].wavelengths.hist(wavelength=500).plot()"
+    "choppers[0].wavelengths.data.hist(wavelength=300).plot()"
    ]
   }
  ],

--- a/src/tof/component.py
+++ b/src/tof/component.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 
+import plopp as pp
 import scipp as sc
 
 
@@ -25,5 +26,29 @@ class Component:
             coords={'wavelength': w},
         )
 
-    def plot(self, bins: int = 300):
-        return self.tofs.hist(tof=bins).plot()
+    @property
+    def blocked_tofs(self) -> sc.Variable:
+        t = self._arrival_times[~self._mask].to(unit='us')
+        return sc.DataArray(
+            data=sc.ones(sizes=t.sizes, unit='counts'), coords={'tof': t}
+        )
+
+    @property
+    def blocked_wavelengths(self) -> sc.Variable:
+        w = self._wavelengths[~self._mask]
+        return sc.DataArray(
+            data=sc.ones(sizes=w.sizes, unit='counts'),
+            coords={'wavelength': w},
+        )
+
+    def plot(self, bins: int = 300, show_blocked: bool = False):
+        if show_blocked:
+            return pp.plot(
+                {
+                    'visible': self.tofs.hist(tof=bins),
+                    'blocked': self.blocked_tofs.hist(tof=bins),
+                },
+                color={'blocked': 'gray'},
+            )
+        else:
+            return self.tofs.hist(tof=bins).plot()

--- a/src/tof/component.py
+++ b/src/tof/component.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 
+from typing import Union
+
 import plopp as pp
 import scipp as sc
 
@@ -41,8 +43,20 @@ class Component:
             coords={'wavelength': w},
         )
 
-    def plot(self, bins: int = 300, show_blocked: bool = False):
+    def plot(self, bins: Union[int, sc.Variable] = 300, show_blocked: bool = False):
+        tofs = self.tofs
+        btofs = self.blocked_tofs
         if show_blocked:
+            if isinstance(bins, int):
+                bins = sc.linspace(
+                    dim='tof',
+                    start=min(
+                        tofs.coords['tof'].min(), btofs.coords['tof'].min()
+                    ).value,
+                    stop=max(tofs.coords['tof'].max(), btofs.coords['tof'].max()).value,
+                    num=bins,
+                    unit=tofs.coords['tof'].unit,
+                )
             return pp.plot(
                 {
                     'visible': self.tofs.hist(tof=bins),

--- a/src/tof/component.py
+++ b/src/tof/component.py
@@ -45,24 +45,21 @@ class Component:
 
     def plot(self, bins: Union[int, sc.Variable] = 300, show_blocked: bool = False):
         tofs = self.tofs
+        if not show_blocked:
+            return tofs.hist(tof=bins).plot()
         btofs = self.blocked_tofs
-        if show_blocked:
-            if isinstance(bins, int):
-                bins = sc.linspace(
-                    dim='tof',
-                    start=min(
-                        tofs.coords['tof'].min(), btofs.coords['tof'].min()
-                    ).value,
-                    stop=max(tofs.coords['tof'].max(), btofs.coords['tof'].max()).value,
-                    num=bins,
-                    unit=tofs.coords['tof'].unit,
-                )
-            return pp.plot(
-                {
-                    'visible': self.tofs.hist(tof=bins),
-                    'blocked': self.blocked_tofs.hist(tof=bins),
-                },
-                color={'blocked': 'gray'},
+        if isinstance(bins, int):
+            bins = sc.linspace(
+                dim='tof',
+                start=min(tofs.coords['tof'].min(), btofs.coords['tof'].min()).value,
+                stop=max(tofs.coords['tof'].max(), btofs.coords['tof'].max()).value,
+                num=bins,
+                unit=tofs.coords['tof'].unit,
             )
-        else:
-            return self.tofs.hist(tof=bins).plot()
+        return pp.plot(
+            {
+                'visible': tofs.hist(tof=bins),
+                'blocked': btofs.hist(tof=bins),
+            },
+            color={'blocked': 'gray'},
+        )

--- a/src/tof/model.py
+++ b/src/tof/model.py
@@ -87,6 +87,28 @@ class Model:
         #     selection_mask = slice(None)
         # else:
 
+        # Blocked rays
+        if blocked_rays > 0:
+            inv_mask = ~furthest_detector._mask
+            tofs = furthest_detector._arrival_times[inv_mask].to(unit='us')
+            if len(tofs) > blocked_rays:
+                inds = np.random.choice(len(tofs), size=blocked_rays, replace=False)
+            else:
+                inds = slice(None)
+            birth_times = self.pulse.birth_times[inv_mask][inds]
+
+            # chopper_masks = [c._mask[inv_mask][inds] for c in self.choppers]
+            chopper_masks = sc.concat(
+                [c._mask[inv_mask][inds] for c in self.choppers], dim='chopper'
+            )
+            self._add_rays(
+                ax=ax,
+                tofs=tofs[inds],
+                birth_times=birth_times,
+                distances=distances,
+                wavelengths=wavelengths,
+            )
+
         # Normal rays
         tofs = furthest_detector.tofs.coords['tof']
         if (max_rays is not None) and (len(tofs) > max_rays):

--- a/src/tof/model.py
+++ b/src/tof/model.py
@@ -39,6 +39,9 @@ class Model:
         initial_mask = sc.ones(
             sizes=self.pulse.birth_times.sizes, unit=None, dtype=bool
         )
+        previous_mask = sc.zeros(
+            sizes=self.pulse.birth_times.sizes, unit=None, dtype=bool
+        )
         for comp in components:
             comp._wavelengths = self.pulse.wavelengths
             t = self.pulse.birth_times + comp.distance / self.pulse.speeds
@@ -53,7 +56,9 @@ class Model:
                 m |= (t > to[i]) & (t < tc[i])
             combined = initial_mask & m
             comp._mask = combined
+            comp._own_mask = ~m & ~previous_mask
             initial_mask = combined
+            previous_mask = ~m
 
     def _add_rays(self, ax, tofs, birth_times, distances, wavelengths=None):
         x0 = birth_times.to(unit='us', copy=False).values.reshape(-1, 1)

--- a/src/tof/model.py
+++ b/src/tof/model.py
@@ -124,7 +124,7 @@ class Model:
 
         # Normal rays
         if max_rays > 0:
-            tofs = furthest_detector.tofs.coords['tof']
+            tofs = furthest_detector.tofs.visible.data.coords['tof']
             if (max_rays is not None) and (len(tofs) > max_rays):
                 inds = np.random.choice(len(tofs), size=max_rays, replace=False)
             else:


### PR DESCRIPTION
Use
```Py
model.plot(max_rays=100, blocked_rays=1000)
```
![Figure 1 (1)](https://user-images.githubusercontent.com/39047984/234271877-d148f8c7-1c54-419f-b832-459197e16288.png)

and

```Py
choppers[1].tofs.visible.plot()
```
![Screenshot at 2023-04-25 15-04-02](https://user-images.githubusercontent.com/39047984/234285109-5b8feb60-15bf-4bc5-abe8-3daa5c12c9f3.png)

```Py
choppers[1].tofs.blocked.plot()
```
![Screenshot at 2023-04-25 15-04-41](https://user-images.githubusercontent.com/39047984/234285242-9ee03834-a064-4bef-b12c-72cf8859a5fa.png)

```Py
choppers[1].tofs.plot()
```
![Screenshot at 2023-04-25 15-05-13](https://user-images.githubusercontent.com/39047984/234285398-57dcbf2f-f434-4a47-89f6-96a304795c07.png)

**Note:** to access the chopper data, you now have to use
```Py
choppers[1].tofs.visible.data
```