### PR TITLE
Crop a pre-defined pulse by setting limits on time and wavelength

### DIFF
--- a/src/tof/pulse.py
+++ b/src/tof/pulse.py
@@ -14,32 +14,49 @@ from .utils import wavelength_to_speed
 class Pulse:
     def __init__(
         self,
-        tmin: float = Optional[sc.Variable],
-        tmax: float = Optional[sc.Variable],
-        lmin: float = Optional[sc.Variable],
-        lmax: float = Optional[sc.Variable],
+        tmin: Optional[sc.Variable] = None,
+        tmax: Optional[sc.Variable] = None,
+        lmin: Optional[sc.Variable] = None,
+        lmax: Optional[sc.Variable] = None,
         neutrons: int = 1_000_000,
-        kind: str = Optional[None],
-        p_wav: np.ndarray = Optional[None],
-        p_time: np.ndarray = Optional[None],
+        kind: Optional[str] = None,
+        p_wav: Optional[np.ndarray] = None,
+        p_time: Optional[np.ndarray] = None,
         sampling_resolution: int = 10000,
     ):
         self.kind = kind
         self.neutrons = neutrons
+        self.tmin = tmin
+        self.tmax = tmax
+        self.lmin = lmin
+        self.lmax = lmax
+        self.p_wav = p_wav
+        self.p_time = p_time
+        self.sampling_resolution = sampling_resolution
+        self.generate()
 
+    def generate(self):
         if self.kind is not None:
             params = getattr(facilities, self.kind)
-            self.tmin = params['time'].coords['time'].min().to(unit='s')
-            self.tmax = params['time'].coords['time'].max().to(unit='s')
-            self.lmin = (
-                params['wavelength'].coords['wavelength'].min().to(unit='angstrom')
-            )
-            self.lmax = (
-                params['wavelength'].coords['wavelength'].max().to(unit='angstrom')
-            )
+            if self.tmin is None:
+                self.tmin = params['time'].coords['time'].min().to(unit='s')
+            if self.tmax is None:
+                self.tmax = params['time'].coords['time'].max().to(unit='s')
+            if self.lmin is None:
+                self.lmin = (
+                    params['wavelength'].coords['wavelength'].min().to(unit='angstrom')
+                )
+            if self.lmax is None:
+                self.lmax = (
+                    params['wavelength'].coords['wavelength'].max().to(unit='angstrom')
+                )
 
-            x_time = np.linspace(self.tmin.value, self.tmax.value, sampling_resolution)
-            x_wav = np.linspace(self.lmin.value, self.lmax.value, sampling_resolution)
+            x_time = np.linspace(
+                self.tmin.value, self.tmax.value, self.sampling_resolution
+            )
+            x_wav = np.linspace(
+                self.lmin.value, self.lmax.value, self.sampling_resolution
+            )
             p_time = np.interp(
                 x_time,
                 params['time'].coords['time'].to(unit='s').values,
@@ -53,10 +70,12 @@ class Pulse:
             )
             p_wav /= p_wav.sum()
         else:
-            self.tmin = tmin.to(unit='s')
-            self.tmax = tmax.to(unit='s')
-            self.lmin = lmin.to(unit='angstrom')
-            self.lmax = lmax.to(unit='angstrom')
+            self.tmin = self.tmin.to(unit='s')
+            self.tmax = self.tmax.to(unit='s')
+            self.lmin = self.lmin.to(unit='angstrom')
+            self.lmax = self.lmax.to(unit='angstrom')
+            p_time = self.p_time
+            p_wav = self.p_wav
 
         if p_time is not None:
             if self.kind is None:

--- a/src/tof/pulse.py
+++ b/src/tof/pulse.py
@@ -35,21 +35,23 @@ class Pulse:
         self.sampling_resolution = sampling_resolution
         self.generate()
 
-    def generate(self):
+    def generate(self, neutrons: Optional[int] = None):
+        if neutrons is not None:
+            self.neutrons = neutrons
         if self.kind is not None:
             params = getattr(facilities, self.kind)
             if self.tmin is None:
-                self.tmin = params['time'].coords['time'].min().to(unit='s')
+                self.tmin = params['time'].coords['time'].min()
             if self.tmax is None:
-                self.tmax = params['time'].coords['time'].max().to(unit='s')
+                self.tmax = params['time'].coords['time'].max()
             if self.lmin is None:
-                self.lmin = (
-                    params['wavelength'].coords['wavelength'].min().to(unit='angstrom')
-                )
+                self.lmin = params['wavelength'].coords['wavelength'].min()
             if self.lmax is None:
-                self.lmax = (
-                    params['wavelength'].coords['wavelength'].max().to(unit='angstrom')
-                )
+                self.lmax = params['wavelength'].coords['wavelength'].max()
+            self.tmin = self.tmin.to(unit='s')
+            self.tmax = self.tmax.to(unit='s')
+            self.lmin = self.lmin.to(unit='angstrom')
+            self.lmax = self.lmax.to(unit='angstrom')
 
             x_time = np.linspace(
                 self.tmin.value, self.tmax.value, self.sampling_resolution


### PR DESCRIPTION
Previously, setting `tmin/tmax` (time limits) and `lmin/lmax` (wavelength limits) on the pulse had no effect if this was a pre-defined pulse (e.g. the ESS pulse).
Now, these limits crop the existing pulse.