### PR TITLE
Various fixes for when all neutrons are blocked, and some API renaming

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -9,12 +9,12 @@ API Reference
 
    Chopper
    ChopperReading
-   Reading
-   ReadingData
-   Data
+   ComponentReading
    Detector
    DetectorReading
    Model
+   ReadingData
+   ReadingField
    Result
    Source
    SourceParameters

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -9,8 +9,8 @@ API Reference
 
    Chopper
    ChopperReading
-   Component
-   ComponentData
+   Reading
+   ReadingData
    Data
    Detector
    DetectorReading

--- a/src/tof/__init__.py
+++ b/src/tof/__init__.py
@@ -4,8 +4,8 @@
 # flake8: noqa F401
 
 from .chopper import Chopper, ChopperReading
-from .component import Component, ComponentData, Data
 from .detector import Detector, DetectorReading
 from .model import Model
+from .reading import Reading, ReadingData, Data
 from .result import Result
 from .source import Source, SourceParameters

--- a/src/tof/__init__.py
+++ b/src/tof/__init__.py
@@ -6,6 +6,6 @@
 from .chopper import Chopper, ChopperReading
 from .detector import Detector, DetectorReading
 from .model import Model
-from .reading import Reading, ReadingData, Data
+from .reading import Data, Reading, ReadingData
 from .result import Result
 from .source import Source, SourceParameters

--- a/src/tof/__init__.py
+++ b/src/tof/__init__.py
@@ -6,6 +6,6 @@
 from .chopper import Chopper, ChopperReading
 from .detector import Detector, DetectorReading
 from .model import Model
-from .reading import Data, Reading, ReadingData
+from .reading import ComponentReading, ReadingData, ReadingField
 from .result import Result
 from .source import Source, SourceParameters

--- a/src/tof/chopper.py
+++ b/src/tof/chopper.py
@@ -77,6 +77,8 @@ class Chopper:
         if unit is None:
             unit = time_limit.unit
         nrot = max(int(sc.ceil((time_limit * self.frequency).to(unit='')).value), 1)
+        # Start at -1 to catch early openings in case the phase or opening angles are
+        # large
         phases = sc.arange(uuid.uuid4().hex, -1, nrot) * two_pi + self.phase.to(
             unit='rad'
         )

--- a/src/tof/chopper.py
+++ b/src/tof/chopper.py
@@ -7,7 +7,7 @@ from typing import Optional, Tuple
 
 import scipp as sc
 
-from .reading import Reading, ReadingData
+from .reading import ComponentReading, ReadingField
 from .utils import two_pi
 
 
@@ -108,7 +108,7 @@ class Chopper:
 
 
 @dataclass(frozen=True)
-class ChopperReading(Reading):
+class ChopperReading(ComponentReading):
     """
     Read-only container for the neutrons that reach the chopper.
     """
@@ -122,10 +122,10 @@ class ChopperReading(Reading):
     open_times: sc.Variable
     close_times: sc.Variable
     data: sc.DataArray
-    tofs: ReadingData
-    wavelengths: ReadingData
-    birth_times: ReadingData
-    speeds: ReadingData
+    tofs: ReadingField
+    wavelengths: ReadingField
+    birth_times: ReadingField
+    speeds: ReadingField
 
     def __repr__(self) -> str:
         out = f"ChopperReading: '{self.name}'\n"

--- a/src/tof/chopper.py
+++ b/src/tof/chopper.py
@@ -77,7 +77,9 @@ class Chopper:
         if unit is None:
             unit = time_limit.unit
         nrot = max(int(sc.ceil((time_limit * self.frequency).to(unit='')).value), 1)
-        phases = sc.arange(uuid.uuid4().hex, nrot) * two_pi + self.phase.to(unit='rad')
+        phases = sc.arange(uuid.uuid4().hex, -1, nrot) * two_pi + self.phase.to(
+            unit='rad'
+        )
         # Note that the order is important here: we need (phases + open/close) to get
         # the correct dimension order when we flatten below.
         open_times = (phases + self.open.to(unit='rad', copy=False)) / self.omega

--- a/src/tof/chopper.py
+++ b/src/tof/chopper.py
@@ -7,7 +7,7 @@ from typing import Optional, Tuple
 
 import scipp as sc
 
-from .component import Component, ComponentData
+from .reading import Reading, ReadingData
 from .utils import two_pi
 
 
@@ -108,7 +108,7 @@ class Chopper:
 
 
 @dataclass(frozen=True)
-class ChopperReading(Component):
+class ChopperReading(Reading):
     """
     Read-only container for the neutrons that reach the chopper.
     """
@@ -122,10 +122,10 @@ class ChopperReading(Component):
     open_times: sc.Variable
     close_times: sc.Variable
     data: sc.DataArray
-    tofs: ComponentData
-    wavelengths: ComponentData
-    birth_times: ComponentData
-    speeds: ComponentData
+    tofs: ReadingData
+    wavelengths: ReadingData
+    birth_times: ReadingData
+    speeds: ReadingData
 
     def __repr__(self) -> str:
         out = f"Chopper: '{self.name}'\n"

--- a/src/tof/chopper.py
+++ b/src/tof/chopper.py
@@ -128,7 +128,7 @@ class ChopperReading(Reading):
     speeds: ReadingData
 
     def __repr__(self) -> str:
-        out = f"Chopper: '{self.name}'\n"
+        out = f"ChopperReading: '{self.name}'\n"
         out += f"  distance: {self.distance:c}\n"
         out += f"  frequency: {self.frequency:c}\n"
         out += f"  phase: {self.phase:c}\n"

--- a/src/tof/component.py
+++ b/src/tof/component.py
@@ -64,7 +64,14 @@ class Data:
         bins:
             The bins to use for histogramming the neutrons.
         """
-        return self.data.hist({self.dim: bins}).plot(**kwargs)
+        return pp.plot(
+            {
+                key: da.hist({self.dim: bins})
+                for key, da in self.data.items()
+                if da.size > 0
+            },
+            **kwargs,
+        )
 
     def __repr__(self) -> str:
         out = f"Data(dim='{self.dim}')\n"

--- a/src/tof/detector.py
+++ b/src/tof/detector.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 
 import scipp as sc
 
-from .reading import Reading, ReadingData
+from .reading import ComponentReading, ReadingField
 
 
 class Detector:
@@ -33,7 +33,7 @@ class Detector:
 
 
 @dataclass(frozen=True)
-class DetectorReading(Reading):
+class DetectorReading(ComponentReading):
     """
     Read-only container for the neutrons that reach the detector.
     """
@@ -41,10 +41,10 @@ class DetectorReading(Reading):
     distance: sc.Variable
     name: str
     data: sc.DataArray
-    tofs: ReadingData
-    wavelengths: ReadingData
-    birth_times: ReadingData
-    speeds: ReadingData
+    tofs: ReadingField
+    wavelengths: ReadingField
+    birth_times: ReadingField
+    speeds: ReadingField
 
     def __repr__(self) -> str:
         out = f"DetectorReading: '{self.name}'\n"

--- a/src/tof/detector.py
+++ b/src/tof/detector.py
@@ -47,7 +47,7 @@ class DetectorReading(Reading):
     speeds: ReadingData
 
     def __repr__(self) -> str:
-        out = f"Detector: '{self.name}'\n"
+        out = f"DetectorReading: '{self.name}'\n"
         out += f"  distance: {self.distance:c}\n"
         out += "\n".join(
             f"  {key}: {getattr(self, key)}"

--- a/src/tof/detector.py
+++ b/src/tof/detector.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 
 import scipp as sc
 
-from .component import Component, ComponentData
+from .reading import Reading, ReadingData
 
 
 class Detector:
@@ -33,7 +33,7 @@ class Detector:
 
 
 @dataclass(frozen=True)
-class DetectorReading(Component):
+class DetectorReading(Reading):
     """
     Read-only container for the neutrons that reach the detector.
     """
@@ -41,10 +41,10 @@ class DetectorReading(Component):
     distance: sc.Variable
     name: str
     data: sc.DataArray
-    tofs: ComponentData
-    wavelengths: ComponentData
-    birth_times: ComponentData
-    speeds: ComponentData
+    tofs: ReadingData
+    wavelengths: ReadingData
+    birth_times: ReadingData
+    speeds: ReadingData
 
     def __repr__(self) -> str:
         out = f"Detector: '{self.name}'\n"

--- a/src/tof/reading.py
+++ b/src/tof/reading.py
@@ -12,7 +12,7 @@ from .utils import Plot
 
 
 @dataclass(frozen=True)
-class Data:
+class ReadingData:
     """
     A data object contains the data (visible or blocked) for a component data
     (e.g. time-of-flight or wavelengths).
@@ -74,7 +74,7 @@ class Data:
         )
 
     def __repr__(self) -> str:
-        out = f"Data(dim='{self.dim}')\n"
+        out = f"ReadingData(dim='{self.dim}')\n"
         for name, da in self.data.items():
             out += f"  {name}: events={len(da)}"
             if len(da) > 0:
@@ -87,7 +87,7 @@ class Data:
         return self.__repr__()
 
 
-def _field_to_string(field: Data) -> str:
+def _field_to_string(field: ReadingData) -> str:
     if isinstance(field.data, sc.DataArray):
         return str(len(field))
     data = field.data
@@ -101,10 +101,12 @@ def _field_to_string(field: Data) -> str:
 
 
 @dataclass(frozen=True)
-class ReadingData:
+class ReadingField:
     """
-    Contains the data for the visible neutrons. In the case of a :class:`Chopper`,
-    this also contains the data for the blocked neutrons.
+    Contains the data for the visible neutrons of a given field.
+    Possible fields are ``tofs``, ``wavelengths``, ``birth_times``, and ``speeds``.
+    In the case of a :class:`Chopper`, this also contains the data for the blocked
+    neutrons.
 
     Parameters
     ----------
@@ -114,8 +116,8 @@ class ReadingData:
         The blocked neutrons (those that are blocked by the component).
     """
 
-    visible: Data
-    blocked: Optional[Data] = None
+    visible: ReadingData
+    blocked: Optional[ReadingData] = None
 
     @property
     def data(self) -> sc.DataGroup:
@@ -192,11 +194,10 @@ class ReadingData:
         return out
 
 
-class Reading:
+class ComponentReading:
     """
-    Data reading for a component placed in the beam path. After the model is run, the
-    reading will have a record of the arrival times and wavelengths of the neutrons that
-    passed through it.
+    Data reading for a component placed in the beam path. The reading will have a
+    record of the arrival times and wavelengths of the neutrons that passed through it.
     """
 
     def plot(self, bins: int = 300) -> Plot:

--- a/src/tof/reading.py
+++ b/src/tof/reading.py
@@ -15,7 +15,7 @@ from .utils import Plot
 class Data:
     """
     A data object contains the data (visible or blocked) for a component data
-    (time-of-flight or wavelengths).
+    (e.g. time-of-flight or wavelengths).
 
     Parameters
     ----------
@@ -101,24 +101,17 @@ def _field_to_string(field: Data) -> str:
 
 
 @dataclass(frozen=True)
-class ComponentData:
+class ReadingData:
     """
-    A component data object contains the data (time-of-flight or wavelengths) for a
-    component.
+    Contains the data for the visible neutrons. In the case of a :class:`Chopper`,
+    this also contains the data for the blocked neutrons.
 
     Parameters
     ----------
-    data:
-        The data to hold.
-    mask:
-        A mask to apply to the data which will select the neutrons that pass through
-        the component.
-    dim:
-        The dimension label of the data.
-    blocking:
-        A mask to apply to the data which will select the neutrons that are blocked by
-        the component (this only defined in the case of a :class:`Chopper` component
-        since a :class:`Detector` does not block any neutrons).
+    visible:
+        The visible neutrons (those that are not blocked by the component).
+    blocked:
+        The blocked neutrons (those that are blocked by the component).
     """
 
     visible: Data
@@ -148,7 +141,7 @@ class ComponentData:
         return out
 
     def __repr__(self) -> str:
-        return f"ComponentData(dim='{self.visible.dim}', {self._repr_string_body()})"
+        return f"ReadingData(dim='{self.visible.dim}', {self._repr_string_body()})"
 
     def plot(self, bins: Union[int, sc.Variable] = 300, **kwargs):
         """
@@ -199,10 +192,10 @@ class ComponentData:
         return out
 
 
-class Component:
+class Reading:
     """
-    A component is placed in the beam path. After the model is run, the component
-    will have a record of the arrival times and wavelengths of the neutrons that
+    Data reading for a component placed in the beam path. After the model is run, the
+    reading will have a record of the arrival times and wavelengths of the neutrons that
     passed through it.
     """
 

--- a/src/tof/result.py
+++ b/src/tof/result.py
@@ -173,11 +173,11 @@ class Result:
         wmin: sc.Variable,
         wmax: sc.Variable,
     ):
-        if max_rays <= 0:
-            return
         da = furthest_detector.data['pulse', pulse_index]
         visible = da[~da.masks['blocked_by_others']]
         tofs = visible.coords['tof']
+        if (max_rays <= 0) or (len(tofs) == 0):
+            return
         if (max_rays is not None) and (len(tofs) > max_rays):
             inds = np.random.choice(len(tofs), size=max_rays, replace=False)
         else:
@@ -203,11 +203,11 @@ class Result:
         furthest_detector: DetectorReading,
         ax: plt.Axes,
     ):
-        if blocked_rays <= 0:
-            return
         slc = ('pulse', pulse_index)
         inv_mask = ~self._masks[furthest_detector.name][slc]
         nrays = int(inv_mask.sum())
+        if (blocked_rays <= 0) or (nrays == 0):
+            return
         if nrays > blocked_rays:
             inds = np.random.choice(nrays, size=blocked_rays, replace=False)
         else:
@@ -313,12 +313,14 @@ class Result:
             self._plot_pulse(pulse_index=i, ax=ax)
 
         det_data = furthest_detector.tofs.visible.data
-        if len(det_data) == 1:
-            tof_max = det_data['pulse:0'].coords['tof'].max().value
+        if sum([da.sum().value for da in det_data.values()]) > 0:
+            tof_max = reduce(
+                max,
+                [da.coords['tof'].max() for da in det_data.values()],
+            ).value
         else:
             tof_max = reduce(
-                lambda a, b: max(a.max(), b.max()),
-                [da.coords['tof'] for da in det_data.values()],
+                max, [ch.close_times.max() for ch in self._choppers.values()]
             ).value
         dx = 0.05 * tof_max
         # Plot choppers
@@ -329,7 +331,11 @@ class Result:
             x[0::3] = x0
             x[1::3] = 0.5 * (x0 + x1)
             x[2::3] = x1
-            x = np.concatenate([[0], x] + ([[tof_max + dx]] if x[-1] < tof_max else []))
+            x = np.concatenate(
+                ([[0]] if x[0] > 0 else [x[0:1]])
+                + [x]
+                + ([[tof_max + dx]] if x[-1] < tof_max else [])
+            )
             y = np.full_like(x, ch.distance.value)
             y[2::3] = None
             ax.plot(x, y, color="k")

--- a/src/tof/result.py
+++ b/src/tof/result.py
@@ -15,7 +15,7 @@ from matplotlib.collections import LineCollection
 
 from .chopper import Chopper, ChopperReading
 from .detector import Detector, DetectorReading
-from .reading import Data, ReadingData
+from .reading import ReadingData, ReadingField
 from .source import Source, SourceParameters
 from .utils import Plot
 
@@ -31,9 +31,11 @@ def _make_reading_data(component, dim, is_chopper=False):
         if is_chopper:
             bsel = da[da.masks['blocked_by_me']]
             blocked[name] = sc.DataArray(data=bsel.data, coords={dim: bsel.coords[dim]})
-    return ReadingData(
-        visible=Data(data=sc.DataGroup(visible), dim=dim),
-        blocked=Data(data=sc.DataGroup(blocked), dim=dim) if is_chopper else None,
+    return ReadingField(
+        visible=ReadingData(data=sc.DataGroup(visible), dim=dim),
+        blocked=ReadingData(data=sc.DataGroup(blocked), dim=dim)
+        if is_chopper
+        else None,
     )
 
 

--- a/src/tof/result.py
+++ b/src/tof/result.py
@@ -14,13 +14,13 @@ import scipp as sc
 from matplotlib.collections import LineCollection
 
 from .chopper import Chopper, ChopperReading
-from .component import ComponentData, Data
 from .detector import Detector, DetectorReading
+from .reading import ReadingData, Data
 from .source import Source, SourceParameters
 from .utils import Plot
 
 
-def _make_component_data(component, dim, is_chopper=False):
+def _make_reading_data(component, dim, is_chopper=False):
     visible = {}
     blocked = {} if is_chopper else None
     keep_dim = (set(component.dims) - {'pulse'}).pop()
@@ -31,7 +31,7 @@ def _make_component_data(component, dim, is_chopper=False):
         if is_chopper:
             bsel = da[da.masks['blocked_by_me']]
             blocked[name] = sc.DataArray(data=bsel.data, coords={dim: bsel.coords[dim]})
-    return ComponentData(
+    return ReadingData(
         visible=Data(data=sc.DataGroup(visible), dim=dim),
         blocked=Data(data=sc.DataGroup(blocked), dim=dim) if is_chopper else None,
     )
@@ -116,7 +116,7 @@ class Result:
                 close_times=chopper['close_times'],
                 data=chopper['data'],
                 **{
-                    key: _make_component_data(chopper['data'], dim=dim, is_chopper=True)
+                    key: _make_reading_data(chopper['data'], dim=dim, is_chopper=True)
                     for key, dim in fields.items()
                 },
             )
@@ -130,7 +130,7 @@ class Result:
                 name=det['name'],
                 data=det['data'],
                 **{
-                    key: _make_component_data(det['data'], dim=dim)
+                    key: _make_reading_data(det['data'], dim=dim)
                     for key, dim in fields.items()
                 },
             )

--- a/src/tof/result.py
+++ b/src/tof/result.py
@@ -315,10 +315,10 @@ class Result:
             self._plot_pulse(pulse_index=i, ax=ax)
 
         det_data = furthest_detector.tofs.visible.data
-        if sum([da.sum().value for da in det_data.values()]) > 0:
-            times = [da.coords['tof'].max() for da in det_data.values()]
+        if sum(da.sum().value for da in det_data.values()) > 0:
+            times = (da.coords['tof'].max() for da in det_data.values())
         else:
-            times = [ch.close_times.max() for ch in self._choppers.values()]
+            times = (ch.close_times.max() for ch in self._choppers.values())
         tof_max = reduce(max, times).value
         dx = 0.05 * tof_max
         # Plot choppers

--- a/src/tof/result.py
+++ b/src/tof/result.py
@@ -314,14 +314,10 @@ class Result:
 
         det_data = furthest_detector.tofs.visible.data
         if sum([da.sum().value for da in det_data.values()]) > 0:
-            tof_max = reduce(
-                max,
-                [da.coords['tof'].max() for da in det_data.values()],
-            ).value
+            times = [da.coords['tof'].max() for da in det_data.values()]
         else:
-            tof_max = reduce(
-                max, [ch.close_times.max() for ch in self._choppers.values()]
-            ).value
+            times = [ch.close_times.max() for ch in self._choppers.values()]
+        tof_max = reduce(max, times).value
         dx = 0.05 * tof_max
         # Plot choppers
         for ch in self._choppers.values():
@@ -331,11 +327,7 @@ class Result:
             x[0::3] = x0
             x[1::3] = 0.5 * (x0 + x1)
             x[2::3] = x1
-            x = np.concatenate(
-                ([[0]] if x[0] > 0 else [x[0:1]])
-                + [x]
-                + ([[tof_max + dx]] if x[-1] < tof_max else [])
-            )
+            x = np.concatenate(([[0]] if x[0] > 0 else [x[0:1]]) + [x])
             y = np.full_like(x, ch.distance.value)
             y[2::3] = None
             ax.plot(x, y, color="k")

--- a/src/tof/result.py
+++ b/src/tof/result.py
@@ -15,7 +15,7 @@ from matplotlib.collections import LineCollection
 
 from .chopper import Chopper, ChopperReading
 from .detector import Detector, DetectorReading
-from .reading import ReadingData, Data
+from .reading import Data, ReadingData
 from .source import Source, SourceParameters
 from .utils import Plot
 

--- a/tests/chopper_test.py
+++ b/tests/chopper_test.py
@@ -36,8 +36,14 @@ def test_open_close_times_one_rotation():
     )
 
     topen, tclose = chopper.open_close_times(0 * sec)
-    assert sc.identical(topen[0], (10.0 * deg).to(unit='rad') / (two_pi * f))
-    assert sc.identical(tclose[0], (20.0 * deg).to(unit='rad') / (two_pi * f))
+    # Note that choppers perform one rotation before t=0 to make sure
+    # no openings are missed at early times.
+    assert sc.identical(topen[0], ((10.0 * deg).to(unit='rad') - two_pi) / (two_pi * f))
+    assert sc.identical(
+        tclose[0], ((20.0 * deg).to(unit='rad') - two_pi) / (two_pi * f)
+    )
+    assert sc.identical(topen[1], (10.0 * deg).to(unit='rad') / (two_pi * f))
+    assert sc.identical(tclose[1], (20.0 * deg).to(unit='rad') / (two_pi * f))
 
 
 def test_open_close_times_three_rotations():
@@ -55,12 +61,17 @@ def test_open_close_times_three_rotations():
     close0 = (20.0 * deg).to(unit='rad')
     assert sc.identical(
         topen,
-        sc.concat([open0, open0 + two_pi, open0 + 2 * two_pi], dim='cutout')
+        sc.concat(
+            [open0 - two_pi, open0, open0 + two_pi, open0 + 2 * two_pi], dim='cutout'
+        )
         / (two_pi * f),
     )
     assert sc.identical(
         tclose,
-        sc.concat([close0, close0 + two_pi, close0 + 2 * two_pi], dim='cutout')
+        sc.concat(
+            [close0 - two_pi, close0, close0 + two_pi, close0 + 2 * two_pi],
+            dim='cutout',
+        )
         / (two_pi * f),
     )
 
@@ -75,8 +86,8 @@ def test_open_close_angles_scalars_converted_to_arrays():
         distance=5.0 * meter,
     )
     topen, tclose = chopper.open_close_times(0.0 * sec)
-    assert sc.identical(topen[0], (10.0 * deg).to(unit='rad') / (two_pi * f))
-    assert sc.identical(tclose[0], (20.0 * deg).to(unit='rad') / (two_pi * f))
+    assert sc.identical(topen[1], (10.0 * deg).to(unit='rad') / (two_pi * f))
+    assert sc.identical(tclose[1], (20.0 * deg).to(unit='rad') / (two_pi * f))
 
 
 def test_phase():
@@ -97,8 +108,8 @@ def test_phase():
         distance=10.0 * meter,
     )
     topen2, tclose2 = chopper2.open_close_times(0.0 * sec)
-    assert sc.identical(topen2, topen1 + (30.0 * deg).to(unit='rad') / chopper2.omega)
-    assert sc.identical(tclose2, tclose1 + (30.0 * deg).to(unit='rad') / chopper2.omega)
+    assert sc.allclose(topen2, topen1 + (30.0 * deg).to(unit='rad') / chopper2.omega)
+    assert sc.allclose(tclose2, tclose1 + (30.0 * deg).to(unit='rad') / chopper2.omega)
 
 
 def test_phase_int():
@@ -122,5 +133,5 @@ def test_phase_int():
     )
     topen1, tclose1 = chopper1.open_close_times(0.0 * sec)
     topen2, tclose2 = chopper2.open_close_times(0.0 * sec)
-    assert sc.identical(topen1, topen2)
-    assert sc.identical(tclose1, tclose2)
+    assert sc.allclose(topen1, topen2)
+    assert sc.allclose(tclose1, tclose2)

--- a/tests/result_test.py
+++ b/tests/result_test.py
@@ -248,6 +248,13 @@ def test_result_multiple_pulses_plot_with_no_events_in_last_frame_does_not_raise
     res.plot(max_rays=50, blocked_rays=3000)
 
 
+def test_result_all_neutrons_blocked_does_not_raise():
+    model = make_ess_model(frequency=1.0 * Hz)
+    res = model.run()
+    res.plot()
+    res.plot(blocked_rays=500)
+
+
 def test_result_repr_does_not_raise():
     model = make_ess_model()
     res = model.run()


### PR DESCRIPTION
- Renamed `component.py` to `reading.py`
- Renamed `Component` to `ComponentReading`
- Renamed `ComponentData` to `ReadingField`
- Renamed `Data` to `ReadingData`

Make choppers perform one rotation before the start of time, to avoid missing openings at early times for choppers that have large phase or large opening angles.

Fixed plotting for when no neutrons make it to the detector.