### PR TITLE
Add support for counter rotating choppers

### DIFF
--- a/docs/components.ipynb
+++ b/docs/components.ipynb
@@ -185,16 +185,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "654c6f43-b2df-4b25-b46f-5eaf42bcbf27",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "chopper1.open_close_times(0*sc.units.s)"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "3155b564-12e1-4d06-a2dd-d376314713f4",
    "metadata": {},

--- a/docs/components.ipynb
+++ b/docs/components.ipynb
@@ -389,7 +389,7 @@
     "        values=[310.0, 330.0],\n",
     "        unit='deg',\n",
     "    ),\n",
-    "    direction='anticlockwise',\n",
+    "    direction=tof.AntiClockwise,\n",
     "    phase=0.0 * deg,\n",
     "    distance=8 * meter,\n",
     "    name=\"Counter-rotating chopper\",\n",

--- a/docs/components.ipynb
+++ b/docs/components.ipynb
@@ -383,7 +383,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2137f7e0-72df-471a-a2ad-c3d2ffd27839",
+   "id": "0e978761-f2de-423e-9e43-a9e664a85a48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -391,12 +391,12 @@
     "    frequency=10.0 * Hz,\n",
     "    open=sc.array(\n",
     "        dims=['cutout'],\n",
-    "        values=[320.0, 280.0],\n",
+    "        values=[280.0, 320.0],\n",
     "        unit='deg',\n",
     "    ),\n",
     "    close=sc.array(\n",
     "        dims=['cutout'],\n",
-    "        values=[330.0, 310.0],\n",
+    "        values=[310.0, 330.0],\n",
     "        unit='deg',\n",
     "    ),\n",
     "    direction='anticlockwise',\n",
@@ -404,39 +404,9 @@
     "    distance=8 * meter,\n",
     "    name=\"Counter-rotating chopper\",\n",
     ")\n",
-    "chopper"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "768220e4-69cd-433b-98c0-7d57fd641eed",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "chopper.open_close_times(0*sc.Unit('s'))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2f448df5-a748-4bfb-9139-322a7a3b08bc",
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "\n",
     "model = tof.Model(source=source, detectors=[detector], choppers=[chopper])\n",
-    "model"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4d30c4f6-36d9-4b9f-891f-b8f270ebd194",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "res = model.run()\n",
-    "res"
+    "res = model.run()"
    ]
   },
   {
@@ -448,35 +418,6 @@
    "source": [
     "res.plot()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "74cc8f12-b39e-49a3-bc4a-36845762542d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "name = \"Counter-rotating chopper\"\n",
-    "res[name].open_times.values"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0acf794f-0878-41dc-abc9-a1604cada4f7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "res[name].close_times.values"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8aa4f323-7cd7-42a4-8c1a-ea92b48cacd2",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -494,8 +435,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/components.ipynb
+++ b/docs/components.ipynb
@@ -185,6 +185,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "654c6f43-b2df-4b25-b46f-5eaf42bcbf27",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chopper1.open_close_times(0*sc.units.s)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "3155b564-12e1-4d06-a2dd-d376314713f4",
    "metadata": {},
@@ -355,6 +365,118 @@
    "source": [
     "res.detectors['monitor'].plot()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "021f81eb-42c3-4094-981e-ada20eca3fdb",
+   "metadata": {},
+   "source": [
+    "## Counter-rotating chopper\n",
+    "\n",
+    "By default, choppers are rotating clockwise.\n",
+    "This means than when open and close angles of the chopper windows are defined as increasing angles in the anti-clockwise direction,\n",
+    "the first window (with the lowest opening angles) will be the first one to pass in front of the beam.\n",
+    "\n",
+    "To make a chopper rotate in the anti-clockwise direction, use the `direction` argument:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2137f7e0-72df-471a-a2ad-c3d2ffd27839",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chopper = tof.Chopper(\n",
+    "    frequency=10.0 * Hz,\n",
+    "    open=sc.array(\n",
+    "        dims=['cutout'],\n",
+    "        values=[320.0, 280.0],\n",
+    "        unit='deg',\n",
+    "    ),\n",
+    "    close=sc.array(\n",
+    "        dims=['cutout'],\n",
+    "        values=[330.0, 310.0],\n",
+    "        unit='deg',\n",
+    "    ),\n",
+    "    direction='anticlockwise',\n",
+    "    phase=0.0 * deg,\n",
+    "    distance=8 * meter,\n",
+    "    name=\"Counter-rotating chopper\",\n",
+    ")\n",
+    "chopper"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "768220e4-69cd-433b-98c0-7d57fd641eed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chopper.open_close_times(0*sc.Unit('s'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2f448df5-a748-4bfb-9139-322a7a3b08bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = tof.Model(source=source, detectors=[detector], choppers=[chopper])\n",
+    "model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d30c4f6-36d9-4b9f-891f-b8f270ebd194",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res = model.run()\n",
+    "res"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "354e87fd-05e4-4237-84d7-3599610e3403",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "74cc8f12-b39e-49a3-bc4a-36845762542d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "name = \"Counter-rotating chopper\"\n",
+    "res[name].open_times.values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0acf794f-0878-41dc-abc9-a1604cada4f7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res[name].close_times.values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8aa4f323-7cd7-42a4-8c1a-ea92b48cacd2",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -372,7 +494,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/src/tof/__init__.py
+++ b/src/tof/__init__.py
@@ -3,7 +3,7 @@
 
 # flake8: noqa F401
 
-from .chopper import Chopper, ChopperReading, Clockwise, Anticlockwise
+from .chopper import Anticlockwise, Chopper, ChopperReading, Clockwise
 from .detector import Detector, DetectorReading
 from .model import Model
 from .reading import ComponentReading, ReadingData, ReadingField

--- a/src/tof/__init__.py
+++ b/src/tof/__init__.py
@@ -3,7 +3,7 @@
 
 # flake8: noqa F401
 
-from .chopper import Anticlockwise, Chopper, ChopperReading, Clockwise
+from .chopper import AntiClockwise, Chopper, ChopperReading, Clockwise
 from .detector import Detector, DetectorReading
 from .model import Model
 from .reading import ComponentReading, ReadingData, ReadingField

--- a/src/tof/__init__.py
+++ b/src/tof/__init__.py
@@ -3,7 +3,7 @@
 
 # flake8: noqa F401
 
-from .chopper import Chopper, ChopperReading
+from .chopper import Chopper, ChopperReading, Clockwise, Anticlockwise
 from .detector import Detector, DetectorReading
 from .model import Model
 from .reading import ComponentReading, ReadingData, ReadingField

--- a/src/tof/chopper.py
+++ b/src/tof/chopper.py
@@ -26,8 +26,11 @@ class Chopper:
     distance:
         The distance from the source to the chopper.
     phase:
-        The phase of the chopper. The phase offset is applied in the opposite direction
-        to the chopper rotation direction.
+        The phase of the chopper. Because the phase offset implemented as a time delay
+        on real beamline choppers, it is applied in the opposite direction
+        to the chopper rotation direction. For example, if the chopper rotates
+        clockwise, a phase of 10 degrees will shift all window angles by 10 degrees
+        in the anticlockwise direction, which will result in the windows opening later.
     name:
         The name of the chopper.
     """

--- a/src/tof/chopper.py
+++ b/src/tof/chopper.py
@@ -20,21 +20,14 @@ class Chopper:
     frequency:
         The frequency of the chopper. Must be positive.
     open:
-        The opening angles of the chopper cutouts. Note that the order of the values
-        listed here defines the order in which the windows will pass in front of the
-        beam. If your chopper is counter-rotating, you have to list the last window
-        first.
+        The opening angles of the chopper cutouts.
     close:
-        The closing angles of the chopper cutouts. Note that the order of the values
-        listed here defines the order in which the windows will pass in front of the
-        beam. If your chopper is counter-rotating, you have to list the last window
-        first.
+        The closing angles of the chopper cutouts.
     distance:
         The distance from the source to the chopper.
     phase:
-        The phase of the chopper. In addition to the normal phase of the chopper, this
-        can be used to account for the fact that the chopper may be below, above, or
-        to the side of the beam.
+        The phase of the chopper. The phase offset is applied in the opposite direction
+        to the chopper rotation direction.
     name:
         The name of the chopper.
     """

--- a/src/tof/chopper.py
+++ b/src/tof/chopper.py
@@ -56,10 +56,13 @@ class Chopper:
         name: str = "",
     ):
         if frequency <= (0.0 * frequency.unit):
-            raise ValueError(f"Chopper frequency must be positive, got {frequency:c}")
+            raise ValueError(f"Chopper frequency must be positive, got {frequency:c}.")
         self.frequency = frequency.to(dtype=float, copy=False)
         if direction not in (Clockwise, AntiClockwise):
-            raise ValueError(f"Chopper direction must be Clockwise or AntiClockwise")
+            raise ValueError(
+                "Chopper direction must be Clockwise or AntiClockwise"
+                f", got {direction}."
+            )
         self.direction = direction
         self.open = (open if open.dims else open.flatten(to='cutout')).to(
             dtype=float, copy=False

--- a/src/tof/chopper.py
+++ b/src/tof/chopper.py
@@ -18,15 +18,23 @@ class Chopper:
     Parameters
     ----------
     frequency:
-        The frequency of the chopper.
+        The frequency of the chopper. Must be positive.
     open:
-        The opening angles of the chopper cutouts.
+        The opening angles of the chopper cutouts. Note that the order of the values
+        listed here defines the order in which the windows will pass in front of the
+        beam. If your chopper is counter-rotating, you have to list the last window
+        first.
     close:
-        The closing angles of the chopper cutouts.
+        The closing angles of the chopper cutouts. Note that the order of the values
+        listed here defines the order in which the windows will pass in front of the
+        beam. If your chopper is counter-rotating, you have to list the last window
+        first.
     distance:
         The distance from the source to the chopper.
     phase:
-        The phase of the chopper.
+        The phase of the chopper. In addition to the normal phase of the chopper, this
+        can be used to account for the fact that the chopper may be below, above, or
+        to the side of the beam.
     name:
         The name of the chopper.
     """
@@ -40,6 +48,8 @@ class Chopper:
         phase: sc.Variable,
         name: str = "",
     ):
+        if frequency < (0.0 * frequency.unit):
+            raise ValueError(f"Chopper frequency must be positive, got {frequency:c}")
         self.frequency = frequency.to(dtype=float, copy=False)
         self.open = (open if open.dims else open.flatten(to='cutout')).to(
             dtype=float, copy=False

--- a/src/tof/chopper.py
+++ b/src/tof/chopper.py
@@ -65,7 +65,7 @@ class Chopper:
         return two_pi * self.frequency
 
     def open_close_times(
-        self, time_limit: sc.Variable, unit: Optional[str] = None
+        self, time_limit: Optional[sc.Variable] = None, unit: Optional[str] = None
     ) -> Tuple[sc.Variable, sc.Variable]:
         """
         The times at which the chopper opens and closes.
@@ -74,11 +74,13 @@ class Chopper:
         ----------
         time_limit:
             Determines how many rotations the chopper needs to perform to reach the time
-            limit.
+            limit. If not specified, the chopper will perform a single rotation.
         unit:
             The unit of the returned times. If not specified, the unit of `time_limit`
             is used.
         """
+        if time_limit is None:
+            time_limit = sc.scalar(0.0, unit='us')
         if unit is None:
             unit = time_limit.unit
         nrot = max(int(sc.ceil((time_limit * self.frequency).to(unit='')).value), 1)

--- a/src/tof/chopper.py
+++ b/src/tof/chopper.py
@@ -10,7 +10,6 @@ import scipp as sc
 from .reading import ComponentReading, ReadingField
 from .utils import two_pi
 
-
 Clockwise = Literal["clockwise"]
 AntiClockwise = Literal["anticlockwise"]
 

--- a/src/tof/chopper.py
+++ b/src/tof/chopper.py
@@ -42,7 +42,7 @@ class Chopper:
         direction: Literal['clockwise', 'anticlockwise'] = 'clockwise',
         name: str = "",
     ):
-        if frequency < (0.0 * frequency.unit):
+        if frequency <= (0.0 * frequency.unit):
             raise ValueError(f"Chopper frequency must be positive, got {frequency:c}")
         self.frequency = frequency.to(dtype=float, copy=False)
         self.open = (open if open.dims else open.flatten(to='cutout')).to(

--- a/tests/chopper_test.py
+++ b/tests/chopper_test.py
@@ -170,7 +170,7 @@ def test_open_close_times_counter_rotation():
         ),
         phase=ph,
         distance=d,
-        direction='anticlockwise',
+        direction=tof.AntiClockwise,
     )
 
     topen1, tclose1 = chopper1.open_close_times(0.2 * sec)
@@ -189,7 +189,7 @@ def test_open_close_times_counter_rotation_with_phase():
         close=sc.array(dims=['cutout'], values=[90.0], unit='deg'),
         phase=0.0 * deg,
         distance=10.0 * meter,
-        direction='anticlockwise',
+        direction=tof.AntiClockwise,
     )
     topen1, tclose1 = chopper1.open_close_times(0.0 * sec)
     chopper2 = tof.Chopper(
@@ -198,7 +198,7 @@ def test_open_close_times_counter_rotation_with_phase():
         close=sc.array(dims=['cutout'], values=[90.0], unit='deg'),
         phase=30.0 * deg,
         distance=10.0 * meter,
-        direction='anticlockwise',
+        direction=tof.AntiClockwise,
     )
     topen2, tclose2 = chopper2.open_close_times(0.0 * sec)
     assert sc.allclose(

--- a/tests/chopper_test.py
+++ b/tests/chopper_test.py
@@ -207,3 +207,60 @@ def test_open_close_times_counter_rotation_with_phase():
     assert sc.allclose(
         tclose2, tclose1 + (30.0 * deg).to(unit='rad') / abs(chopper2.omega)
     )
+
+
+def test_bad_direction_raises():
+    f = 10.0 * Hz
+    op = sc.array(dims=['cutout'], values=[10.0], unit='deg')
+    cl = sc.array(dims=['cutout'], values=[20.0], unit='deg')
+    d = 10.0 * meter
+    ph = 0.0 * deg
+    tof.Chopper(
+        frequency=f,
+        open=op,
+        close=cl,
+        phase=ph,
+        distance=d,
+        direction=tof.Clockwise,
+    )
+    tof.Chopper(
+        frequency=f,
+        open=op,
+        close=cl,
+        phase=ph,
+        distance=d,
+        direction=tof.AntiClockwise,
+    )
+    with pytest.raises(
+        ValueError, match="Chopper direction must be Clockwise or AntiClockwise"
+    ):
+        tof.Chopper(
+            frequency=f,
+            open=op,
+            close=cl,
+            phase=ph,
+            distance=d,
+            direction='clockwise',
+        )
+    with pytest.raises(
+        ValueError, match="Chopper direction must be Clockwise or AntiClockwise"
+    ):
+        tof.Chopper(
+            frequency=f,
+            open=op,
+            close=cl,
+            phase=ph,
+            distance=d,
+            direction='anti-clockwise',
+        )
+    with pytest.raises(
+        ValueError, match="Chopper direction must be Clockwise or AntiClockwise"
+    ):
+        tof.Chopper(
+            frequency=f,
+            open=op,
+            close=cl,
+            phase=ph,
+            distance=d,
+            direction=1,
+        )

--- a/tests/chopper_test.py
+++ b/tests/chopper_test.py
@@ -147,3 +147,63 @@ def test_frequency_must_be_positive():
             phase=0.0 * deg,
             distance=5.0 * meter,
         )
+
+
+def test_open_close_times_counter_rotation():
+    f = 10.0 * Hz
+    d = 10.0 * meter
+    ph = 0.0 * deg
+    chopper1 = tof.Chopper(
+        frequency=f,
+        open=sc.array(dims=['cutout'], values=[10.0, 90.0], unit='deg'),
+        close=sc.array(dims=['cutout'], values=[20.0, 130.0], unit='deg'),
+        phase=ph,
+        distance=d,
+    )
+    chopper2 = tof.Chopper(
+        frequency=f,
+        open=sc.array(
+            dims=['cutout'], values=[360.0 - 130.0, 360.0 - 20.0], unit='deg'
+        ),
+        close=sc.array(
+            dims=['cutout'], values=[360.0 - 90.0, 360.0 - 10.0], unit='deg'
+        ),
+        phase=ph,
+        distance=d,
+        direction='anticlockwise',
+    )
+
+    topen1, tclose1 = chopper1.open_close_times(0.2 * sec)
+    topen2, tclose2 = chopper2.open_close_times(0.0 * sec)
+    # Note that the first chopper will have one more rotation before t=0, so we slice
+    # out the first two open/close times
+    assert sc.allclose(topen1[2:], topen2)
+    assert sc.allclose(tclose1[2:], tclose2)
+
+
+def test_open_close_times_counter_rotation_with_phase():
+    f = 10.0 * Hz
+    chopper1 = tof.Chopper(
+        frequency=f,
+        open=sc.array(dims=['cutout'], values=[80.0], unit='deg'),
+        close=sc.array(dims=['cutout'], values=[90.0], unit='deg'),
+        phase=0.0 * deg,
+        distance=10.0 * meter,
+        direction='anticlockwise',
+    )
+    topen1, tclose1 = chopper1.open_close_times(0.0 * sec)
+    chopper2 = tof.Chopper(
+        frequency=f,
+        open=sc.array(dims=['cutout'], values=[80.0], unit='deg'),
+        close=sc.array(dims=['cutout'], values=[90.0], unit='deg'),
+        phase=30.0 * deg,
+        distance=10.0 * meter,
+        direction='anticlockwise',
+    )
+    topen2, tclose2 = chopper2.open_close_times(0.0 * sec)
+    assert sc.allclose(
+        topen2, topen1 + (30.0 * deg).to(unit='rad') / abs(chopper2.omega)
+    )
+    assert sc.allclose(
+        tclose2, tclose1 + (30.0 * deg).to(unit='rad') / abs(chopper2.omega)
+    )

--- a/tests/chopper_test.py
+++ b/tests/chopper_test.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 
+import pytest
 import scipp as sc
 
 import tof
@@ -135,3 +136,14 @@ def test_phase_int():
     topen2, tclose2 = chopper2.open_close_times(0.0 * sec)
     assert sc.allclose(topen1, topen2)
     assert sc.allclose(tclose1, tclose2)
+
+
+def test_frequency_must_be_positive():
+    with pytest.raises(ValueError, match="Chopper frequency must be positive"):
+        tof.Chopper(
+            frequency=-1.0 * Hz,
+            open=0.0 * deg,
+            close=10.0 * deg,
+            phase=0.0 * deg,
+            distance=5.0 * meter,
+        )


### PR DESCRIPTION
Add support for counter-rotating choppers via the `direction='anticlockwise'` argument.

After discussions in #44 , I decided that using a classmethod for this is not so useful because the computation of the times when the windows are open/closed are not done upon construction.
They depend on how many rotations need to be performed.

I think the easiest is to have the `direction` argument, set to `clockwise` by default so that current users do not have to change all their notebooks.

We will most probably still use a `classmethod` to create a chopper from nexus parameters.

Supersedes #44 

Fix #5 