### PR TITLE
Update wfm stitching notebook with new frame finding and time overlap removal

### DIFF
--- a/docs/wfm-stitching.ipynb
+++ b/docs/wfm-stitching.ipynb
@@ -344,7 +344,8 @@
    "source": [
     "## Reducing overlap between frames\n",
     "\n",
-    "There is a significant amount of overlap between the two frames, as illustrated by this figure"
+    "There is a small amount of time overlap between some of the frames, as illustrated by this figure\n",
+    "(for example, some of the neutrons that belong to <span style=\"color: #2ca02c;\">frame 2</span> are bleeding into the range that belongs to <span style=\"color: #ff7f0e;\">frame 1</span>)."
    ]
   },
   {
@@ -355,20 +356,18 @@
    "outputs": [],
    "source": [
     "# Define a common binning that covers the entire range\n",
-    "full_wavelengths = (\n",
+    "full_tofs = (\n",
     "    full_beamline_results.detectors[\"detector\"]\n",
-    "    .wavelengths.visible.data['pulse:0']\n",
-    "    .coords['wavelength']\n",
+    "    .tofs.visible.data['pulse:0']\n",
+    "    .coords['tof']\n",
     ")\n",
-    "bins = sc.linspace(\n",
-    "    'wavelength', full_wavelengths.min(), full_wavelengths.max(), num=301\n",
-    ")\n",
+    "bins = sc.linspace('tof', full_tofs.min(), full_tofs.max(), num=301)\n",
     "\n",
     "pp.plot(\n",
     "    {\n",
     "        f\"Frame-{i}\": res.detectors[\"detector\"]\n",
-    "        .wavelengths.visible.data['pulse:0']\n",
-    "        .hist(wavelength=bins)\n",
+    "        .tofs.visible.data['pulse:0']\n",
+    "        .hist(tof=bins)\n",
     "        for i, res in enumerate(results)\n",
     "    }\n",
     ")"
@@ -376,28 +375,28 @@
   },
   {
    "cell_type": "markdown",
-   "id": "542d589d-0a46-4503-a37b-ce2435403aad",
+   "id": "8f76007b-da07-4fa7-8ce2-98d57bcbd2c4",
    "metadata": {},
    "source": [
-    "Reducing or removing overlap between frames is beneficial as it reduces the appearance of artifacts between frames in the final wavelength spectrum.\n",
+    "Regions where time of flight overlaps between frames are regions where the wavelength of a neutron cannot accurately be determined,\n",
+    "as neutrons have the same arrival time at the detector,\n",
+    "but different start times at the source end of the beamline.\n",
     "\n",
-    "To achieve this as follows:\n",
+    "They are usually a sign of a faulty design in the chopper cascade,\n",
+    "and we thus need to discard neutrons from any overlapping regions in our final result.\n",
     "\n",
-    "1. we use percentiles (3% and 97%) to remove wavelength outliers in each frame.\n",
-    "1. we find the maximum wavelength in frame $i$ and the minimum wavelength in frame $i+1$.\n",
-    "1. we compute the mean of these two wavelengths.\n",
-    "1. we remove all neutrons in frame $i$ with wavelengths above the mean.\n",
-    "1. we remove all neutrons in frame $i+1$ with wavelengths below the mean."
+    "One way to achieve this is to remove the outliers from the edges of the frames, until the frames no longer overlap.\n",
+    "This is done below by gradually increasing percentile threshold on the `tof` reading at the detector until overlap is gone."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63564c46-37ae-4d62-9ee5-01b9c5fa5125",
+   "id": "8eb2487f-8a15-473b-bd21-ef5142be857c",
    "metadata": {},
    "outputs": [],
    "source": [
-    "percentile = 3.0\n",
+    "percentile_step = 0.1  # Step by which to increase percentile thresholds\n",
     "\n",
     "non_overlapping = []\n",
     "for res in results:\n",
@@ -406,15 +405,20 @@
     "\n",
     "for i in range(len(results) - 1):\n",
     "    # Find mean wavelength between frames\n",
-    "    wavs1 = non_overlapping[i].coords['wavelength']\n",
-    "    wavs2 = non_overlapping[i + 1].coords['wavelength']\n",
-    "    # Remove wavelength outliers\n",
-    "    wmax = np.percentile(wavs1.values, 100 - percentile)\n",
-    "    wmin = np.percentile(wavs2.values, percentile)\n",
-    "    wmean = 0.5 * (wmin + wmax) * wavs1.unit\n",
-    "    # Filter on wavelengths\n",
-    "    non_overlapping[i] = non_overlapping[i][wavs1 <= wmean]\n",
-    "    non_overlapping[i + 1] = non_overlapping[i + 1][wavs2 >= wmean]\n",
+    "    tofs1 = non_overlapping[i].coords['tof']\n",
+    "    tofs2 = non_overlapping[i + 1].coords['tof']\n",
+    "    p = 0.0\n",
+    "    overlap = True\n",
+    "    while overlap:\n",
+    "        tofmin = np.percentile(tofs2.values, p)\n",
+    "        tofmax = np.percentile(tofs1.values, 100 - p)\n",
+    "        overlap = tofmin < tofmax\n",
+    "        p += percentile_step\n",
+    "    # Filter on tofs\n",
+    "    non_overlapping[i] = non_overlapping[i][tofs1 <= sc.scalar(tofmax, unit=tofs1.unit)]\n",
+    "    non_overlapping[i + 1] = non_overlapping[i + 1][\n",
+    "        tofs2 >= sc.scalar(tofmin, unit=tofs2.unit)\n",
+    "    ]\n",
     "\n",
     "for frame in non_overlapping:\n",
     "    w = frame.coords[\"wavelength\"]\n",
@@ -544,8 +548,7 @@
    "id": "54b85305-c89b-4077-97c2-10c447793725",
    "metadata": {},
    "source": [
-    "It is important to note here that, because we removed the wavelength overlap between frames,\n",
-    "the max wavelength of frame $i$ should be equal (or very close) to the min wavelength of frame $i+1$."
+    "It is important to note here that the maximum wavelength of frame $i$ should be close to the minimum wavelength of frame $i+1$."
    ]
   },
   {
@@ -714,11 +717,11 @@
    "source": [
     "pp.plot(\n",
     "    {\n",
-    "        \"naive\": wav_naive.hist(wavelength=bins),\n",
-    "        \"wfm\": wav_wfm.hist(wavelength=bins),\n",
+    "        \"naive\": wav_naive.hist(wavelength=300),\n",
+    "        \"wfm\": wav_wfm.hist(wavelength=300),\n",
     "        \"truth\": full_beamline_results[\"detector\"]\n",
     "        .wavelengths.data[\"visible\"][\"pulse:0\"]\n",
-    "        .hist(wavelength=bins),\n",
+    "        .hist(wavelength=300),\n",
     "    }\n",
     ")"
    ]

--- a/docs/wfm-stitching.ipynb
+++ b/docs/wfm-stitching.ipynb
@@ -209,7 +209,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib widget\n",
     "model = tof.Model(source=source, choppers=choppers, detectors=detectors)\n",
     "full_beamline_results = model.run()\n",
     "full_beamline_results.plot(blocked_rays=5000)"

--- a/docs/wfm-stitching.ipynb
+++ b/docs/wfm-stitching.ipynb
@@ -40,7 +40,7 @@
    "source": [
     "## Create a source pulse\n",
     "\n",
-    "We first create a source with one pulse containing 1 million neutrons whose distribution follows the ESS time and wavelength profiles (both thermal and cold neutrons are included)."
+    "We first create a source with one pulse containing 500,000 neutrons whose distribution follows the ESS time and wavelength profiles (both thermal and cold neutrons are included)."
    ]
   },
   {
@@ -50,8 +50,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "source = tof.Source(facility=\"ess\", neutrons=1_000_000)\n",
+    "source = tof.Source(facility=\"ess\", neutrons=500_000)\n",
     "source.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b39e97a-d6d7-4e75-8095-f7b0206a1bd0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "source.data"
    ]
   },
   {
@@ -184,94 +194,254 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4deb2f50-92b7-4838-b180-17e3ce43743d",
+   "metadata": {},
+   "source": [
+    "## Run the simulation\n",
+    "\n",
+    "We propagate our pulse of neutrons through the chopper cascade and inspect the results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5812eda-2e56-4f72-89bc-4e778046243f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib widget\n",
+    "model = tof.Model(source=source, choppers=choppers, detectors=detectors)\n",
+    "full_beamline_results = model.run()\n",
+    "full_beamline_results.plot(blocked_rays=5000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0de3d295-5e38-4ab2-b8af-601e47b42f19",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "full_beamline_results['detector'].plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "fcb52d39-56d6-4cfb-8bcd-be9f45f4cc70",
    "metadata": {},
    "source": [
     "## Find WFM frame edges\n",
     "\n",
     "To compute the frame edges, we use one of the openings in the WFM choppers at a time,\n",
-    "run the `tof` simulation, and find the min and max tof of the neutrons that make it through the chopper cascade."
+    "run the `tof` simulation, and find the min and max tof of the neutrons that make it through the chopper cascade.\n",
+    "\n",
+    "### Finding the fastest and slowest neutrons\n",
+    "\n",
+    "To find the range of chopper open and close times relevant to this pulse,\n",
+    "we find the times at which the slowest and fastest neutrons went through the two WFM choppers.\n",
+    "\n",
+    "This will then be used to select the correct chopper openings to compute the WFM time corrections before converting flight times to wavelengths."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20597dbd-5204-49fc-8867-9a9ba73fd8de",
+   "id": "c4f98281-d4f6-4ed4-8a24-adf8ae2a22c6",
    "metadata": {},
    "outputs": [],
    "source": [
-    "nframes = len(choppers[0].open)\n",
-    "results = []\n",
+    "# Get the neutrons that make it to the detector\n",
+    "da = full_beamline_results['detector'].data.squeeze()\n",
+    "visible = da[~da.masks['blocked_by_others']]\n",
     "\n",
-    "print(\"Computing frames\")\n",
+    "# Find fastest and slowest neutrons\n",
+    "id_fast = visible[np.argmin(visible.coords['tof'])].coords['id']\n",
+    "id_slow = visible[np.argmax(visible.coords['tof'])].coords['id']\n",
     "\n",
-    "# Run the model with a single frame at a time\n",
-    "for i in range(nframes):\n",
-    "    wfm_choppers = [\n",
-    "        tof.Chopper(\n",
-    "            frequency=choppers[j].frequency,\n",
-    "            open=choppers[j].open[i : i + 1],\n",
-    "            close=choppers[j].close[i : i + 1],\n",
-    "            phase=choppers[j].phase,\n",
-    "            distance=choppers[j].distance,\n",
-    "            name=choppers[j].name,\n",
-    "        )\n",
-    "        for j in (0, 1)\n",
-    "    ]\n",
-    "    new_choppers = wfm_choppers + choppers[2:]\n",
-    "    model = tof.Model(source=source, choppers=new_choppers, detectors=detectors)\n",
-    "    res = model.run()\n",
-    "    results.append(res)\n",
+    "# Compute the times when those neutrons crossed the WFM choppers\n",
+    "tfast = {}\n",
+    "tslow = {}\n",
+    "for key in (\"WFM1\", \"WFM2\"):\n",
+    "    data = full_beamline_results[key].data.squeeze()\n",
+    "    tfast[key] = data['id', id_fast].coords['tof']\n",
+    "    tslow[key] = data['id', id_slow].coords['tof']\n",
     "\n",
-    "invalid_frames = True\n",
-    "fact = 0.01\n",
-    "while invalid_frames:\n",
-    "    print(f\"Searching for bounds: threshold={fact:.2f}\")\n",
-    "    frame_bounds = []\n",
-    "    for res in results:\n",
-    "        tofs = res.detectors[\"detector\"].tofs.data[\"visible\"][\"pulse:0\"].hist(tof=500)\n",
-    "        tofs.coords[\"tof\"] = sc.midpoints(tofs.coords[\"tof\"])\n",
-    "        # We need to filter out the outliers because some stray rays from other frames make it through\n",
-    "        filtered = tofs[tofs.data > fact * tofs.data.max()].coords[\"tof\"]\n",
-    "        frame_bounds.append((filtered.min(), filtered.max()))\n",
-    "    if all(\n",
-    "        frame_bounds[k][1] < frame_bounds[k + 1][0]\n",
-    "        for k in range(len(frame_bounds) - 1)\n",
-    "    ):\n",
-    "        invalid_frames = False\n",
-    "    else:\n",
-    "        fact += 0.01"
+    "tfast, tslow"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "866a02f3-6314-40b5-ac1c-cd8ddacee366",
+   "id": "961e39f8-e305-4b8a-a048-6e55f30a1077",
    "metadata": {},
    "source": [
-    "The edges of the frames are the following"
+    "### Using one choppers opening at a time\n",
+    "\n",
+    "For each WFM choppers, we propagate the neutrons using one openings at a time,\n",
+    "to find which combinations of openings lead to a frame on the detector."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ed050525-7f88-4bb2-af2f-827d1d7afe92",
+   "id": "18b30390-cea5-4493-b6e4-26ad53c13600",
    "metadata": {},
    "outputs": [],
    "source": [
-    "frame_bounds"
+    "ncutouts = len(choppers[0].open)\n",
+    "results = []\n",
+    "time_offsets = []\n",
+    "\n",
+    "print(\"Computing frames\")\n",
+    "new_choppers = {c.name: c for c in choppers}\n",
+    "\n",
+    "# Run the model with a single frame at a time\n",
+    "for i in range(ncutouts):\n",
+    "    new_choppers['WFM1'] = tof.Chopper(\n",
+    "        **choppers[0].as_dict()\n",
+    "    )  # make a copy of the chopper\n",
+    "    new_choppers['WFM1'].open = choppers[0].open[i : i + 1]\n",
+    "    new_choppers['WFM1'].close = choppers[0].close[i : i + 1]\n",
+    "    for j in range(ncutouts):\n",
+    "        new_choppers['WFM2'] = tof.Chopper(\n",
+    "            **choppers[1].as_dict()\n",
+    "        )  # make a copy of the chopper\n",
+    "        new_choppers['WFM2'].open = choppers[1].open[j : j + 1]\n",
+    "        new_choppers['WFM2'].close = choppers[1].close[j : j + 1]\n",
+    "        # Run the simulation using one opening from each WFM chopper\n",
+    "        res = tof.Model(\n",
+    "            source=source, choppers=list(new_choppers.values()), detectors=detectors\n",
+    "        ).run()\n",
+    "        if res.detectors[\"detector\"].tofs.data[\"visible\"].sizes['event'] != 0:\n",
+    "            print(f'Frame found for chopper WFM1:cutout{i}, WFM2:cutout{j}')\n",
+    "            # Append to result list\n",
+    "            results.append(res)\n",
+    "            # Record the chopper opening and close time for this frame\n",
+    "            times = []\n",
+    "            for key in (\"WFM1\", \"WFM2\"):\n",
+    "                topen, tclose = new_choppers[key].open_close_times()\n",
+    "                # Chopper open/close times main contain multiple rotations, and we\n",
+    "                # thus need to select the rotation that is relevant for the pulse of interest\n",
+    "                sel = (tclose > tfast[key]) & (topen < tslow[key])\n",
+    "                times.extend([topen[sel], tclose[sel]])\n",
+    "            time_offsets.append(sc.concat(times, dim='x').mean())"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a5283e4c-699d-4669-a1ff-3f86a751cd68",
+   "id": "a979f0ce-cdb5-4df7-a002-3a6ae1c07a71",
    "metadata": {},
    "outputs": [],
    "source": [
+    "# The offsets are not guaranteed to be sorted, but some code below needs them to be\n",
+    "time_offsets, results = zip(*sorted(zip(time_offsets, results)))\n",
+    "time_offsets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd6f1373-3da1-4779-8671-77af39382dd4",
+   "metadata": {},
+   "source": [
+    "## Reducing overlap between frames\n",
+    "\n",
+    "There is a significant amount of overlap between the two frames, as illustrated by this figure"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5a83f634-9d0f-4668-97dd-eb6130a44d13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define a common binning that covers the entire range\n",
+    "full_wavelengths = (\n",
+    "    full_beamline_results.detectors[\"detector\"]\n",
+    "    .wavelengths.visible.data['pulse:0']\n",
+    "    .coords['wavelength']\n",
+    ")\n",
+    "bins = sc.linspace(\n",
+    "    'wavelength', full_wavelengths.min(), full_wavelengths.max(), num=301\n",
+    ")\n",
+    "\n",
+    "pp.plot(\n",
+    "    {\n",
+    "        f\"Frame-{i}\": res.detectors[\"detector\"]\n",
+    "        .wavelengths.visible.data['pulse:0']\n",
+    "        .hist(wavelength=bins)\n",
+    "        for i, res in enumerate(results)\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "542d589d-0a46-4503-a37b-ce2435403aad",
+   "metadata": {},
+   "source": [
+    "Reducing or removing overlap between frames is beneficial as it reduces the appearance of artifacts between frames in the final wavelength spectrum.\n",
+    "\n",
+    "To achieve this as follows:\n",
+    "\n",
+    "1. we use percentiles (3% and 97%) to remove wavelength outliers in each frame.\n",
+    "1. we find the maximum wavelength in frame $i$ and the minimum wavelength in frame $i+1$.\n",
+    "1. we compute the mean of these two wavelengths.\n",
+    "1. we remove all neutrons in frame $i$ with wavelengths above the mean.\n",
+    "1. we remove all neutrons in frame $i+1$ with wavelengths below the mean."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "63564c46-37ae-4d62-9ee5-01b9c5fa5125",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "percentile = 3.0\n",
+    "\n",
+    "non_overlapping = []\n",
+    "for res in results:\n",
+    "    data = res.detectors[\"detector\"].data.squeeze()\n",
+    "    non_overlapping.append(data[~data.masks['blocked_by_others']])\n",
+    "\n",
+    "for i in range(len(results) - 1):\n",
+    "    # Find mean wavelength between frames\n",
+    "    wavs1 = non_overlapping[i].coords['wavelength']\n",
+    "    wavs2 = non_overlapping[i + 1].coords['wavelength']\n",
+    "    # Remove wavelength outliers\n",
+    "    wmax = np.percentile(wavs1.values, 100 - percentile)\n",
+    "    wmin = np.percentile(wavs2.values, percentile)\n",
+    "    wmean = 0.5 * (wmin + wmax) * wavs1.unit\n",
+    "    # Filter on wavelengths\n",
+    "    non_overlapping[i] = non_overlapping[i][wavs1 <= wmean]\n",
+    "    non_overlapping[i + 1] = non_overlapping[i + 1][wavs2 >= wmean]\n",
+    "\n",
+    "for frame in non_overlapping:\n",
+    "    w = frame.coords[\"wavelength\"]\n",
+    "    t = frame.coords[\"tof\"]\n",
+    "    print(\n",
+    "        f\"Neutrons={len(frame)}, wmin={w.min():c}, wmax={w.max():c}, tofmin={t.min():c}, tofmax={t.max():c}\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "92f8e2fd-c95a-4a80-b06b-e3b8a00a819c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Store the frame bounds to a format used by the stitching\n",
     "frames = sc.DataGroup(\n",
     "    {\n",
-    "        \"time_min\": sc.concat([b[0] for b in frame_bounds], dim=\"frame\"),\n",
-    "        \"time_max\": sc.concat([b[1] for b in frame_bounds], dim=\"frame\"),\n",
+    "        \"time_min\": sc.concat(\n",
+    "            [data.coords['tof'].min() for data in non_overlapping], dim=\"frame\"\n",
+    "        ),\n",
+    "        \"time_max\": sc.concat(\n",
+    "            [data.coords['tof'].max() for data in non_overlapping], dim=\"frame\"\n",
+    "        ),\n",
+    "        \"time_correction\": sc.concat(time_offsets, dim='frame'),\n",
     "    }\n",
     ")\n",
     "frames"
@@ -282,27 +452,28 @@
    "id": "3891b351-4c17-42c2-9c88-68facd82b2aa",
    "metadata": {},
    "source": [
-    "### Inspecting the frames\n",
+    "## Inspecting the frames\n",
     "\n",
-    "As a consistency check, we can run the model with all of the chopper openings, and overlay the frame bounds,\n",
-    "to verify that there is no overlap between the frames."
+    "### Tof frame boundaries\n",
+    "\n",
+    "As a consistency check,\n",
+    "we can overlay the frame bounds onto the detector reading to verify that each frame spans the expected `tof` range,\n",
+    "and that there is no overlap between the frames."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d425e97a-247f-47ac-ad85-10b6cb1fea0e",
+   "id": "fe74cce8-5fd5-41ec-8906-3af6ee3ed539",
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = tof.Model(source=source, choppers=choppers, detectors=detectors)\n",
-    "res = model.run()\n",
-    "f = res.detectors[\"detector\"].tofs.plot(legend=False)\n",
-    "for i, bound in enumerate(frame_bounds):\n",
-    "    col = f\"C{i + 1}\"\n",
-    "    f.ax.axvspan(bound[0].value, bound[1].value, alpha=0.1, color=col)\n",
-    "    f.ax.axvline(bound[0].value, color=col)\n",
-    "    f.ax.axvline(bound[1].value, color=col)\n",
+    "f = full_beamline_results.detectors[\"detector\"].tofs.plot(legend=False, color='k')\n",
+    "for i, (left, right) in enumerate(zip(frames[\"time_min\"], frames[\"time_max\"])):\n",
+    "    col = f\"C{i}\"\n",
+    "    f.ax.axvspan(left.value, right.value, alpha=0.1, color=col)\n",
+    "    f.ax.axvline(left.value, color=col)\n",
+    "    f.ax.axvline(right.value, color=col)\n",
     "f"
    ]
   },
@@ -320,22 +491,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35f59c87-7435-4248-b8df-c05a1eda0c5e",
+   "id": "aa48153f-25ac-4cb8-afc7-8b15d7305e9d",
    "metadata": {},
    "outputs": [],
    "source": [
     "frame_min = []\n",
     "frame_max = []\n",
     "\n",
-    "for i in range(nframes):\n",
-    "    print(\"frame\", i)\n",
-    "    da = results[i][\"detector\"].data.squeeze()\n",
-    "    da = da[~da.masks[\"blocked_by_others\"]]\n",
-    "    ts = da.coords[\"tof\"]\n",
-    "    sel = (ts > frames[\"time_min\"][i]) & (ts < frames[\"time_max\"][i])\n",
-    "    filtered = da[sel]\n",
-    "    frame_min.append(filtered[np.argmin(filtered.coords[\"tof\"])])\n",
-    "    frame_max.append(filtered[np.argmax(filtered.coords[\"tof\"])])\n",
+    "for data in non_overlapping:\n",
+    "    ind_min = np.argmin(data.coords['wavelength'].values)\n",
+    "    ind_max = np.argmax(data.coords['wavelength'].values)\n",
+    "    frame_min.append(data[ind_min])\n",
+    "    frame_max.append(data[ind_max])\n",
     "\n",
     "# Create a source by manually setting neutron birth times and wavelengths\n",
     "birth_times = sc.concat(\n",
@@ -347,7 +514,9 @@
     "    + [f.coords[\"wavelength\"] for f in frame_max],\n",
     "    dim=\"event\",\n",
     ")\n",
-    "source_min_max = tof.Source.from_neutrons(birth_times=birth_times, wavelengths=wavelengths)\n",
+    "source_min_max = tof.Source.from_neutrons(\n",
+    "    birth_times=birth_times, wavelengths=wavelengths\n",
+    ")\n",
     "source_min_max"
    ]
   },
@@ -376,7 +545,8 @@
    "id": "54b85305-c89b-4077-97c2-10c447793725",
    "metadata": {},
    "source": [
-    "What is interesting, and also a contract of WFM, is that the wavelength of the slowest neutron in one frame is very close to the wavelength of the fastest neutron in the next frame."
+    "It is important to note here that, because we removed the wavelength overlap between frames,\n",
+    "the max wavelength of frame $i$ should be equal (or very close) to the min wavelength of frame $i+1$."
    ]
   },
   {
@@ -405,7 +575,7 @@
    "outputs": [],
    "source": [
     "# Extract the tof data of the events that make it through to the detector\n",
-    "tofs = res[\"detector\"].tofs.data[\"visible\"][\"pulse:0\"].copy()\n",
+    "tofs = full_beamline_results[\"detector\"].tofs.data[\"visible\"][\"pulse:0\"].copy()\n",
     "tofs.coords[\"source_position\"] = sc.vector([0.0, 0.0, 0.0], unit=\"m\")\n",
     "tofs.coords[\"position\"] = sc.vector(\n",
     "    [0.0, 0.0, detectors[0].distance.value], unit=detectors[0].distance.unit\n",
@@ -435,8 +605,9 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
-   "id": "f72c4e94-2052-488d-90d3-113af1334287",
+   "id": "922f2585-8eab-4a22-9583-4dee71932815",
    "metadata": {},
    "source": [
     "### Computing time-of-flight from WFM choppers to detector\n",
@@ -445,42 +616,9 @@
     "This means that the distance used for the flight is from the WFM choppers to the detector,\n",
     "and the flight time is from when the choppers open to the arrival time at detector.\n",
     "\n",
-    "We first get the times when the choppers are open (mid-point between open and close times for the 2 WFM choppers):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7d792986-194a-4714-9e75-f7a038102f43",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "times_wfm1 = choppers[0].open_close_times()\n",
-    "times_wfm2 = choppers[1].open_close_times()\n",
+    "Those were computed above, and stored as `time_correction` in the `frames` data group.\n",
     "\n",
-    "corrections = [\n",
-    "    sc.concat(\n",
-    "        [\n",
-    "            times_wfm1[0][i + nframes],  # open wfm1\n",
-    "            times_wfm1[1][i + nframes],  # close wfm1\n",
-    "            times_wfm2[0][i + nframes],  # open wfm2\n",
-    "            times_wfm2[1][i + nframes],  # close wfm2\n",
-    "        ],\n",
-    "        dim=\"x\",\n",
-    "    ).mean()\n",
-    "    for i in range(nframes)\n",
-    "]\n",
-    "\n",
-    "frames[\"time_correction\"] = sc.concat(corrections, dim=\"frame\")\n",
-    "frames"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8c7daac3-b38f-41e4-a90d-b9daf2d18a1b",
-   "metadata": {},
-   "source": [
-    "We apply the correction which effectively 'stitches' the data back together:"
+    "We apply the corrections, which effectively 'stitches' the data back together:"
    ]
   },
   {
@@ -577,11 +715,11 @@
    "source": [
     "pp.plot(\n",
     "    {\n",
-    "        \"naive\": wav_naive.hist(wavelength=300),\n",
-    "        \"wfm\": wav_wfm.hist(wavelength=300),\n",
-    "        \"truth\": res[\"detector\"]\n",
+    "        \"naive\": wav_naive.hist(wavelength=bins),\n",
+    "        \"wfm\": wav_wfm.hist(wavelength=bins),\n",
+    "        \"truth\": full_beamline_results[\"detector\"]\n",
     "        .wavelengths.data[\"visible\"][\"pulse:0\"]\n",
-    "        .hist(wavelength=300),\n",
+    "        .hist(wavelength=bins),\n",
     "    }\n",
     ")"
    ]

--- a/src/tof/source.py
+++ b/src/tof/source.py
@@ -152,7 +152,9 @@ def _make_pulses(
         unit=TIME_UNIT,
     ).fold(dim=dim, sizes={"pulse": pulses, dim: neutrons}) + (
         sc.arange("pulse", pulses) / frequency
-    ).to(unit=TIME_UNIT, copy=False)
+    ).to(
+        unit=TIME_UNIT, copy=False
+    )
 
     wavelength = sc.array(
         dims=[dim],

--- a/src/tof/source.py
+++ b/src/tof/source.py
@@ -152,9 +152,7 @@ def _make_pulses(
         unit=TIME_UNIT,
     ).fold(dim=dim, sizes={"pulse": pulses, dim: neutrons}) + (
         sc.arange("pulse", pulses) / frequency
-    ).to(
-        unit=TIME_UNIT, copy=False
-    )
+    ).to(unit=TIME_UNIT, copy=False)
 
     wavelength = sc.array(
         dims=[dim],
@@ -226,6 +224,9 @@ class Source:
                     "time": pulse_params["time"],
                     "wavelength": pulse_params["wavelength"],
                     "speed": pulse_params["speed"],
+                    "id": sc.arange("event", pulse_params["time"].size).fold(
+                        "event", sizes=pulse_params["time"].sizes
+                    ),
                 },
             )
 
@@ -270,6 +271,9 @@ class Source:
                 "time": birth_times,
                 "wavelength": wavelengths,
                 "speed": wavelength_to_speed(wavelengths).to(unit="m/s", copy=False),
+                "id": sc.arange("event", birth_times.size).fold(
+                    "event", sizes=birth_times.sizes
+                ),
             },
         )
 
@@ -326,6 +330,9 @@ class Source:
                 "time": pulse_params["time"],
                 "wavelength": pulse_params["wavelength"],
                 "speed": pulse_params["speed"],
+                "id": sc.arange("event", pulse_params["time"].size).fold(
+                    "event", sizes=pulse_params["time"].sizes
+                ),
             },
         )
         return source


### PR DESCRIPTION
- We use the more general frame finding approach used in the DREAM choppers setup to find the individual WFM frames.
- We also introduce removal of time overlap between frames, by gradually increasing percentile cutoffs on the tofs of consecutive frames.
- In the process, we also added individual ids to the neutrons in a source, which are useful and used in this example.

Depends on #51 