### PR TITLE
Allow to create choppers from centers and widths of cutouts

### DIFF
--- a/src/tof/chopper.py
+++ b/src/tof/chopper.py
@@ -41,16 +41,16 @@ class Chopper:
         The opening angles of the chopper cutouts.
     close:
         The closing angles of the chopper cutouts.
-    center:
-        The center of the chopper cutouts.
-    width:
-        The width of the chopper cutouts.
+    centers:
+        The centers of the chopper cutouts.
+    widths:
+        The widths of the chopper cutouts.
     name:
         The name of the chopper.
 
     Notes
     -----
-    Either `open` and `close` or `center` and `width` must be provided, but not both.
+    Either `open` and `close` or `centers` and `widths` must be provided, but not both.
     """
 
     def __init__(
@@ -61,8 +61,8 @@ class Chopper:
         phase: sc.Variable,
         open: sc.Variable | None = None,
         close: sc.Variable | None = None,
-        center: sc.Variable | None = None,
-        width: sc.Variable | None = None,
+        centers: sc.Variable | None = None,
+        widths: sc.Variable | None = None,
         direction: Direction = Clockwise,
         name: str = "",
     ):
@@ -76,18 +76,18 @@ class Chopper:
             )
         self.direction = direction
         # Check that either open/close or center/width are provided, but not both
-        if tuple(x for x in (open, close, center, width) if x is not None) not in (
+        if tuple(x for x in (open, close, centers, widths) if x is not None) not in (
             (open, close),
-            (center, width),
+            (centers, widths),
         ):
             raise ValueError(
-                "Either open/close or center/width must be provided, got"
-                f" open={open}, close={close}, center={center}, width={width}."
+                "Either open/close or centers/widths must be provided, got"
+                f" open={open}, close={close}, center={centers}, width={widths}."
             )
         if open is None:
-            half_width = width * 0.5
-            open = center - half_width
-            close = center + half_width
+            half_width = widths * 0.5
+            open = centers - half_width
+            close = centers + half_width
 
         self.open = (open if open.dims else open.flatten(to='cutout')).to(
             dtype=float, copy=False

--- a/src/tof/chopper.py
+++ b/src/tof/chopper.py
@@ -29,10 +29,6 @@ class Chopper:
     ----------
     frequency:
         The frequency of the chopper. Must be positive.
-    open:
-        The opening angles of the chopper cutouts.
-    close:
-        The closing angles of the chopper cutouts.
     distance:
         The distance from the source to the chopper.
     phase:
@@ -41,17 +37,32 @@ class Chopper:
         to the chopper rotation direction. For example, if the chopper rotates
         clockwise, a phase of 10 degrees will shift all window angles by 10 degrees
         in the anticlockwise direction, which will result in the windows opening later.
+    open:
+        The opening angles of the chopper cutouts.
+    close:
+        The closing angles of the chopper cutouts.
+    center:
+        The center of the chopper cutouts.
+    width:
+        The width of the chopper cutouts.
     name:
         The name of the chopper.
+
+    Notes
+    -----
+    Either `open` and `close` or `center` and `width` must be provided, but not both.
     """
 
     def __init__(
         self,
+        *,
         frequency: sc.Variable,
-        open: sc.Variable,
-        close: sc.Variable,
         distance: sc.Variable,
         phase: sc.Variable,
+        open: sc.Variable | None = None,
+        close: sc.Variable | None = None,
+        center: sc.Variable | None = None,
+        width: sc.Variable | None = None,
         direction: Direction = Clockwise,
         name: str = "",
     ):
@@ -64,6 +75,20 @@ class Chopper:
                 f", got {direction}."
             )
         self.direction = direction
+        # Check that either open/close or center/width are provided, but not both
+        if tuple(x for x in (open, close, center, width) if x is not None) not in (
+            (open, close),
+            (center, width),
+        ):
+            raise ValueError(
+                "Either open/close or center/width must be provided, got"
+                f" open={open}, close={close}, center={center}, width={width}."
+            )
+        if open is None:
+            half_width = width * 0.5
+            open = center - half_width
+            close = center + half_width
+
         self.open = (open if open.dims else open.flatten(to='cutout')).to(
             dtype=float, copy=False
         )

--- a/src/tof/chopper.py
+++ b/src/tof/chopper.py
@@ -75,7 +75,7 @@ class Chopper:
                 f", got {direction}."
             )
         self.direction = direction
-        # Check that either open/close or center/width are provided, but not both
+        # Check that either open/close or centers/widths are provided, but not both
         if tuple(x for x in (open, close, centers, widths) if x is not None) not in (
             (open, close),
             (centers, widths),

--- a/src/tof/chopper.py
+++ b/src/tof/chopper.py
@@ -82,7 +82,7 @@ class Chopper:
         ):
             raise ValueError(
                 "Either open/close or centers/widths must be provided, got"
-                f" open={open}, close={close}, center={centers}, width={widths}."
+                f" open={open}, close={close}, centers={centers}, widths={widths}."
             )
         if open is None:
             half_width = widths * 0.5

--- a/tests/chopper_test.py
+++ b/tests/chopper_test.py
@@ -291,3 +291,43 @@ def test_bad_direction_raises():
             distance=d,
             direction=1,
         )
+
+
+def test_chopper_create_from_centers_and_widths():
+    f = 10.0 * Hz
+    center = sc.array(dims=['cutout'], values=[15.0, 46.0], unit='deg')
+    width = sc.array(dims=['cutout'], values=[10.0, 16.0], unit='deg')
+    chopper = tof.Chopper(
+        frequency=f,
+        center=center,
+        width=width,
+        phase=0.0 * deg,
+        distance=5.0 * meter,
+    )
+    assert sc.allclose(chopper.open, center - width / 2)
+    assert sc.allclose(chopper.close, center + width / 2)
+
+    expected = tof.Chopper(
+        frequency=f,
+        open=sc.array(dims=['cutout'], values=[10.0, 38.0], unit='deg'),
+        close=sc.array(dims=['cutout'], values=[20.0, 54.0], unit='deg'),
+        phase=0.0 * deg,
+        distance=5.0 * meter,
+    )
+    assert sc.allclose(chopper.open, expected.open)
+    assert sc.allclose(chopper.close, expected.close)
+
+
+def test_chopper_create_raises_when_both_edges_and_centers_are_supplied():
+    with pytest.raises(
+        ValueError, match="Either open/close or center/width must be provided"
+    ):
+        tof.Chopper(
+            frequency=10.0 * Hz,
+            open=10.0 * deg,
+            close=20.0 * deg,
+            center=15.0 * deg,
+            width=10.0 * deg,
+            phase=0.0 * deg,
+            distance=5.0 * meter,
+        )

--- a/tests/chopper_test.py
+++ b/tests/chopper_test.py
@@ -295,17 +295,17 @@ def test_bad_direction_raises():
 
 def test_chopper_create_from_centers_and_widths():
     f = 10.0 * Hz
-    center = sc.array(dims=['cutout'], values=[15.0, 46.0], unit='deg')
-    width = sc.array(dims=['cutout'], values=[10.0, 16.0], unit='deg')
+    centers = sc.array(dims=['cutout'], values=[15.0, 46.0], unit='deg')
+    widths = sc.array(dims=['cutout'], values=[10.0, 16.0], unit='deg')
     chopper = tof.Chopper(
         frequency=f,
-        center=center,
-        width=width,
+        centers=centers,
+        widths=widths,
         phase=0.0 * deg,
         distance=5.0 * meter,
     )
-    assert sc.allclose(chopper.open, center - width / 2)
-    assert sc.allclose(chopper.close, center + width / 2)
+    assert sc.allclose(chopper.open, centers - widths / 2)
+    assert sc.allclose(chopper.close, centers + widths / 2)
 
     expected = tof.Chopper(
         frequency=f,
@@ -320,14 +320,14 @@ def test_chopper_create_from_centers_and_widths():
 
 def test_chopper_create_raises_when_both_edges_and_centers_are_supplied():
     with pytest.raises(
-        ValueError, match="Either open/close or center/width must be provided"
+        ValueError, match="Either open/close or centers/widths must be provided"
     ):
         tof.Chopper(
             frequency=10.0 * Hz,
             open=10.0 * deg,
             close=20.0 * deg,
-            center=15.0 * deg,
-            width=10.0 * deg,
+            centers=15.0 * deg,
+            widths=10.0 * deg,
             phase=0.0 * deg,
             distance=5.0 * meter,
         )


### PR DESCRIPTION
Allow to create choppers from centers and widths of cutouts in addition to open and close angles.
Choppers are defined in terms of slit centers and widths in McStas.

Example:
```Py
tof.Chopper(
        frequency=14*Hz,
        direction=tof.AntiClockwise,
        width=sc.array(
            dims=['cutout'],
            values=[2.46, 3.02, 3.27, 3.27, 5.02, 3.93, 3.93, 2.46],
            unit='deg',
        ),
        center=sc.array(
            dims=['cutout'],
            values=[0, 72, 86.4, 115.2, 172.8, 273.6, 288.0, 302.4],
            unit='deg',
        ),
        phase=(286-180)*deg,
        distance= 6.145*meter, 
        name="PSC1",
    )
```