### PR TITLE
Rename `tof` coordinate to `toa`

### DIFF
--- a/docs/components.ipynb
+++ b/docs/components.ipynb
@@ -108,7 +108,7 @@
    "id": "34267819-4f83-48c6-b51b-9f13742ac3da",
    "metadata": {},
    "source": [
-    "The data itself is available via the `.tofs`, `.wavelengths`, `.birth_times`, and `.speeds` properties,\n",
+    "The data itself is available via the `.toas`, `.wavelengths`, `.birth_times`, and `.speeds` properties,\n",
     "depending on which one you wish to inspect.\n",
     "\n",
     "Note that we here need to have the additional `.visible` property in the chain,\n",
@@ -123,7 +123,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "res.detectors['detector'].tofs.visible.data"
+    "res.detectors['detector'].toas.visible.data"
    ]
   },
   {
@@ -202,7 +202,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "res.choppers['Chopper1'].tofs.plot()"
+    "res.choppers['Chopper1'].toas.plot()"
    ]
   },
   {
@@ -223,7 +223,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "res.detectors['detector'].tofs.plot()"
+    "res.detectors['detector'].toas.plot()"
    ]
   },
   {

--- a/docs/multiple-pulses.ipynb
+++ b/docs/multiple-pulses.ipynb
@@ -196,7 +196,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "res.detectors['detector'].tofs.plot()"
+    "res.detectors['detector'].toas.plot()"
    ]
   },
   {
@@ -253,7 +253,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "res.detectors['detector'].tofs.plot()"
+    "res.detectors['detector'].toas.plot()"
    ]
   },
   {
@@ -273,7 +273,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "res.detectors['detector'].tofs.visible.data"
+    "res.detectors['detector'].toas.visible.data"
    ]
   },
   {
@@ -291,7 +291,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "res.detectors['detector'].tofs.visible[0].data"
+    "res.detectors['detector'].toas.visible[0].data"
    ]
   },
   {
@@ -301,7 +301,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "res.detectors['detector'].tofs.visible[0].plot()"
+    "res.detectors['detector'].toas.visible[0].plot()"
    ]
   },
   {
@@ -309,7 +309,7 @@
    "id": "e3388ce1-f766-4162-b254-22c3f564f3d1",
    "metadata": {},
    "source": [
-    "and the same is available one level above on the `tofs` property,\n",
+    "and the same is available one level above on the `toas` property,\n",
     "in which case both visible and blocked neutrons for the given pulse are returned:"
    ]
   },
@@ -320,7 +320,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "res.choppers['WFM1'].tofs[0].plot()"
+    "res.choppers['WFM1'].toas[0].plot()"
    ]
   }
  ],

--- a/docs/short-example.ipynb
+++ b/docs/short-example.ipynb
@@ -245,7 +245,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "res.detectors['monitor'].tofs.plot()"
+    "res.detectors['monitor'].toas.plot()"
    ]
   },
   {
@@ -255,7 +255,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "res.choppers[\"Frame-overlap 2\"].tofs.plot()"
+    "res.choppers[\"Frame-overlap 2\"].toas.plot()"
    ]
   },
   {
@@ -284,7 +284,7 @@
    "id": "9b01bb60-da73-442c-a734-36d455375b8d",
    "metadata": {},
    "source": [
-    "The `.tofs`, `.wavelengths`, `.birth_times`, and `.speeds` properties of the beamline components return a proxy object,\n",
+    "The `.toas`, `.wavelengths`, `.birth_times`, and `.speeds` properties of the beamline components return a proxy object,\n",
     "which gives access to the data they hold.\n",
     "\n",
     "Accessing their `.data` returns a data group with both visible and blocked neutrons:"
@@ -297,7 +297,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "res.choppers['WFM1'].tofs.data"
+    "res.choppers['WFM1'].toas.data"
    ]
   },
   {
@@ -315,7 +315,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "res.choppers['WFM1'].tofs.visible.data"
+    "res.choppers['WFM1'].toas.visible.data"
    ]
   },
   {

--- a/docs/wfm-stitching.ipynb
+++ b/docs/wfm-stitching.ipynb
@@ -229,7 +229,7 @@
     "    print(f\"Searching for bounds: threshold={fact:.2f}\")\n",
     "    frame_bounds = []\n",
     "    for res in results:\n",
-    "        toas = res.detectors[\"detector\"].toas.data[\"visible\"][\"pulse:0\"].hist(tof=500)\n",
+    "        toas = res.detectors[\"detector\"].toas.data[\"visible\"][\"pulse:0\"].hist(toa=500)\n",
     "        toas.coords[\"tof\"] = sc.midpoints(toas.coords[\"tof\"])\n",
     "        # We need to filter out the outliers because some stray rays from other frames make it through\n",
     "        filtered = toas[toas.data > fact * toas.data.max()].coords[\"tof\"]\n",

--- a/docs/wfm-stitching.ipynb
+++ b/docs/wfm-stitching.ipynb
@@ -347,7 +347,9 @@
     "    + [f.coords[\"wavelength\"] for f in frame_max],\n",
     "    dim=\"event\",\n",
     ")\n",
-    "source_min_max = tof.Source.from_neutrons(birth_times=birth_times, wavelengths=wavelengths)\n",
+    "source_min_max = tof.Source.from_neutrons(\n",
+    "    birth_times=birth_times, wavelengths=wavelengths\n",
+    ")\n",
     "source_min_max"
    ]
   },
@@ -384,14 +386,14 @@
    "id": "c808287b-e569-48c6-a964-ee19d06380ef",
    "metadata": {},
    "source": [
-    "## Stitching the data: computing a new time-of-flight\n",
+    "## Stitching the data: computing time-of-flight\n",
     "\n",
     "Using WFM choppers allows us to re-define the burst time of the neutrons, and compute a more accurate wavelength.\n",
     "\n",
     "In the following, we use the boundaries of the frames to select neutrons in each frame,\n",
-    "and apply a correction to the time-of-flight of those neutrons which corresponds to the time when the WFM choppers are open.\n",
+    "and compute a time-of-flight between the time when the WFM choppers are open and the time of arrival at detector.\n",
     "\n",
-    "### Computing wavelengths from the naive time-of-flight\n",
+    "### Computing wavelengths from the naive time-of-arrival\n",
     "\n",
     "We first begin by computing the neutron wavelengths as if there were no WFM choppers.\n",
     "We take the distance from the source to the detector, and use the neutron arrival time at the detector to compute a speed and hence a wavelength."
@@ -410,6 +412,7 @@
     "toas.coords[\"position\"] = sc.vector(\n",
     "    [0.0, 0.0, detectors[0].distance.value], unit=detectors[0].distance.unit\n",
     ")\n",
+    "toas.coords[\"tof\"] = toas.coords[\"toa\"]  # Scippneutron requires a tof coordinate\n",
     "toas"
    ]
   },
@@ -418,7 +421,7 @@
    "id": "1584ab73-9a08-43e5-9047-9f8ec15e56e4",
    "metadata": {},
    "source": [
-    "Converting the time-of-flight to wavelength is done using Scipp's `transform_coords`:"
+    "Converting the time-of-arrival to wavelength is done using Scipp's `transform_coords`:"
    ]
   },
   {
@@ -428,8 +431,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Make a coordinate transformation graph to compute wavelength from tof\n",
-    "graph = {**beamline(scatter=False), **elastic(\"toa\")}\n",
+    "# Make a coordinate transformation graph to compute wavelength from toa\n",
+    "graph = {**beamline(scatter=False), **elastic(\"tof\")}\n",
     "wav_naive = toas.transform_coords(\"wavelength\", graph=graph)\n",
     "wav_naive.hist(wavelength=300).plot()"
    ]
@@ -555,6 +558,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "wfm_toas.bins.coords[\"tof\"] = wfm_toas.bins.coords[\"toa\"]\n",
     "wav_wfm = wfm_toas.transform_coords(\"wavelength\", graph=graph)"
    ]
   },

--- a/docs/wfm-stitching.ipynb
+++ b/docs/wfm-stitching.ipynb
@@ -230,9 +230,9 @@
     "    frame_bounds = []\n",
     "    for res in results:\n",
     "        toas = res.detectors[\"detector\"].toas.data[\"visible\"][\"pulse:0\"].hist(toa=500)\n",
-    "        toas.coords[\"tof\"] = sc.midpoints(toas.coords[\"tof\"])\n",
+    "        toas.coords[\"toa\"] = sc.midpoints(toas.coords[\"toa\"])\n",
     "        # We need to filter out the outliers because some stray rays from other frames make it through\n",
-    "        filtered = toas[toas.data > fact * toas.data.max()].coords[\"tof\"]\n",
+    "        filtered = toas[toas.data > fact * toas.data.max()].coords[\"toa\"]\n",
     "        frame_bounds.append((filtered.min(), filtered.max()))\n",
     "    if all(\n",
     "        frame_bounds[k][1] < frame_bounds[k + 1][0]\n",
@@ -331,11 +331,11 @@
     "    print(\"frame\", i)\n",
     "    da = results[i][\"detector\"].data.squeeze()\n",
     "    da = da[~da.masks[\"blocked_by_others\"]]\n",
-    "    ts = da.coords[\"tof\"]\n",
+    "    ts = da.coords[\"toa\"]\n",
     "    sel = (ts > frames[\"time_min\"][i]) & (ts < frames[\"time_max\"][i])\n",
     "    filtered = da[sel]\n",
-    "    frame_min.append(filtered[np.argmin(filtered.coords[\"tof\"])])\n",
-    "    frame_max.append(filtered[np.argmax(filtered.coords[\"tof\"])])\n",
+    "    frame_min.append(filtered[np.argmin(filtered.coords[\"toa\"])])\n",
+    "    frame_max.append(filtered[np.argmax(filtered.coords[\"toa\"])])\n",
     "\n",
     "# Create a source by manually setting neutron birth times and wavelengths\n",
     "birth_times = sc.concat(\n",
@@ -429,7 +429,7 @@
    "outputs": [],
    "source": [
     "# Make a coordinate transformation graph to compute wavelength from tof\n",
-    "graph = {**beamline(scatter=False), **elastic(\"tof\")}\n",
+    "graph = {**beamline(scatter=False), **elastic(\"toa\")}\n",
     "wav_naive = toas.transform_coords(\"wavelength\", graph=graph)\n",
     "wav_naive.hist(wavelength=300).plot()"
    ]
@@ -515,7 +515,7 @@
     "    return binned.bins.concat()\n",
     "\n",
     "\n",
-    "wfm_toas = stitch(data=toas, frames=frames, dim=\"tof\")"
+    "wfm_toas = stitch(data=toas, frames=frames, dim=\"toa\")"
    ]
   },
   {

--- a/docs/wfm-stitching.ipynb
+++ b/docs/wfm-stitching.ipynb
@@ -229,10 +229,10 @@
     "    print(f\"Searching for bounds: threshold={fact:.2f}\")\n",
     "    frame_bounds = []\n",
     "    for res in results:\n",
-    "        tofs = res.detectors[\"detector\"].tofs.data[\"visible\"][\"pulse:0\"].hist(tof=500)\n",
-    "        tofs.coords[\"tof\"] = sc.midpoints(tofs.coords[\"tof\"])\n",
+    "        toas = res.detectors[\"detector\"].toas.data[\"visible\"][\"pulse:0\"].hist(tof=500)\n",
+    "        toas.coords[\"tof\"] = sc.midpoints(toas.coords[\"tof\"])\n",
     "        # We need to filter out the outliers because some stray rays from other frames make it through\n",
-    "        filtered = tofs[tofs.data > fact * tofs.data.max()].coords[\"tof\"]\n",
+    "        filtered = toas[toas.data > fact * toas.data.max()].coords[\"tof\"]\n",
     "        frame_bounds.append((filtered.min(), filtered.max()))\n",
     "    if all(\n",
     "        frame_bounds[k][1] < frame_bounds[k + 1][0]\n",
@@ -297,7 +297,7 @@
    "source": [
     "model = tof.Model(source=source, choppers=choppers, detectors=detectors)\n",
     "res = model.run()\n",
-    "f = res.detectors[\"detector\"].tofs.plot(legend=False)\n",
+    "f = res.detectors[\"detector\"].toas.plot(legend=False)\n",
     "for i, bound in enumerate(frame_bounds):\n",
     "    col = f\"C{i + 1}\"\n",
     "    f.ax.axvspan(bound[0].value, bound[1].value, alpha=0.1, color=col)\n",
@@ -405,12 +405,12 @@
    "outputs": [],
    "source": [
     "# Extract the tof data of the events that make it through to the detector\n",
-    "tofs = res[\"detector\"].tofs.data[\"visible\"][\"pulse:0\"].copy()\n",
-    "tofs.coords[\"source_position\"] = sc.vector([0.0, 0.0, 0.0], unit=\"m\")\n",
-    "tofs.coords[\"position\"] = sc.vector(\n",
+    "toas = res[\"detector\"].toas.data[\"visible\"][\"pulse:0\"].copy()\n",
+    "toas.coords[\"source_position\"] = sc.vector([0.0, 0.0, 0.0], unit=\"m\")\n",
+    "toas.coords[\"position\"] = sc.vector(\n",
     "    [0.0, 0.0, detectors[0].distance.value], unit=detectors[0].distance.unit\n",
     ")\n",
-    "tofs"
+    "toas"
    ]
   },
   {
@@ -430,7 +430,7 @@
    "source": [
     "# Make a coordinate transformation graph to compute wavelength from tof\n",
     "graph = {**beamline(scatter=False), **elastic(\"tof\")}\n",
-    "wav_naive = tofs.transform_coords(\"wavelength\", graph=graph)\n",
+    "wav_naive = toas.transform_coords(\"wavelength\", graph=graph)\n",
     "wav_naive.hist(wavelength=300).plot()"
    ]
   },
@@ -515,7 +515,7 @@
     "    return binned.bins.concat()\n",
     "\n",
     "\n",
-    "wfm_tofs = stitch(data=tofs, frames=frames, dim=\"tof\")"
+    "wfm_toas = stitch(data=toas, frames=frames, dim=\"tof\")"
    ]
   },
   {
@@ -533,11 +533,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "wfm_tofs.coords[\"source_position\"] = sc.vector(\n",
+    "wfm_toas.coords[\"source_position\"] = sc.vector(\n",
     "    [0.0, 0.0, 0.5 * (choppers[0].distance.value + choppers[1].distance.value)],\n",
     "    unit=choppers[0].distance.unit,\n",
     ")\n",
-    "wfm_tofs"
+    "wfm_toas"
    ]
   },
   {
@@ -555,7 +555,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "wav_wfm = wfm_tofs.transform_coords(\"wavelength\", graph=graph)"
+    "wav_wfm = wfm_toas.transform_coords(\"wavelength\", graph=graph)"
    ]
   },
   {

--- a/src/tof/chopper.py
+++ b/src/tof/chopper.py
@@ -8,6 +8,7 @@ from typing import Optional, Tuple
 
 import scipp as sc
 
+from .deprecation import deprecated
 from .reading import ComponentReading, ReadingField
 from .utils import two_pi
 
@@ -214,3 +215,8 @@ class ChopperReading(ComponentReading):
 
     def __str__(self) -> str:
         return self.__repr__()
+
+    @property
+    @deprecated("Use 'toas' instead.")
+    def tofs(self) -> ReadingField:
+        return self.toas

--- a/src/tof/chopper.py
+++ b/src/tof/chopper.py
@@ -195,7 +195,7 @@ class ChopperReading(ComponentReading):
     open_times: sc.Variable
     close_times: sc.Variable
     data: sc.DataArray
-    tofs: ReadingField
+    toas: ReadingField
     wavelengths: ReadingField
     birth_times: ReadingField
     speeds: ReadingField
@@ -208,7 +208,7 @@ class ChopperReading(ComponentReading):
         out += f"  cutouts: {len(self.open)}\n"
         out += "\n".join(
             f"  {key}: {getattr(self, key)}"
-            for key in ('tofs', 'wavelengths', 'birth_times', 'speeds')
+            for key in ('toas', 'wavelengths', 'birth_times', 'speeds')
         )
         return out
 

--- a/src/tof/deprecation.py
+++ b/src/tof/deprecation.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
+
+import functools
+import warnings
+from collections.abc import Callable
+
+
+class VisibleDeprecationWarning(UserWarning):
+    """Visible deprecation warning.
+
+    By default, Python and in particular Jupyter will not show deprecation
+    warnings, so this class can be used when a very visible warning is helpful.
+    """
+
+
+VisibleDeprecationWarning.__module__ = 'tof'
+
+
+def deprecated(message: str = '') -> Callable:
+    def decorator(function: Callable) -> Callable:
+        @functools.wraps(function)
+        def wrapper(*args, **kwargs):
+            warnings.warn(
+                f'{function.__name__} is deprecated. {message}',
+                VisibleDeprecationWarning,
+                stacklevel=2,
+            )
+            return function(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+__all__ = ['deprecated']

--- a/src/tof/detector.py
+++ b/src/tof/detector.py
@@ -41,7 +41,7 @@ class DetectorReading(ComponentReading):
     distance: sc.Variable
     name: str
     data: sc.DataArray
-    tofs: ReadingField
+    toas: ReadingField
     wavelengths: ReadingField
     birth_times: ReadingField
     speeds: ReadingField
@@ -51,7 +51,7 @@ class DetectorReading(ComponentReading):
         out += f"  distance: {self.distance:c}\n"
         out += "\n".join(
             f"  {key}: {getattr(self, key)}"
-            for key in ('tofs', 'wavelengths', 'birth_times', 'speeds')
+            for key in ('toas', 'wavelengths', 'birth_times', 'speeds')
         )
         return out
 

--- a/src/tof/detector.py
+++ b/src/tof/detector.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 
 import scipp as sc
 
+from .deprecation import deprecated
 from .reading import ComponentReading, ReadingField
 
 
@@ -57,3 +58,8 @@ class DetectorReading(ComponentReading):
 
     def __str__(self) -> str:
         return self.__repr__()
+
+    @property
+    @deprecated("Use 'toas' instead.")
+    def tofs(self) -> ReadingField:
+        return self.toas

--- a/src/tof/model.py
+++ b/src/tof/model.py
@@ -144,6 +144,8 @@ class Model:
             container[c.name]['data'] = self.source.data.copy(deep=False)
             t = birth_time + (c.distance / speed).to(unit=birth_time.unit, copy=False)
             container[c.name]['data'].coords['toa'] = t
+            # TODO: remove 'tof' coordinate once deprecation period is over
+            container[c.name]['data'].coords['tof'] = t
             if isinstance(c, Detector):
                 container[c.name]['visible_mask'] = initial_mask
                 container[c.name]['data'].masks['blocked_by_others'] = ~initial_mask

--- a/src/tof/model.py
+++ b/src/tof/model.py
@@ -143,7 +143,7 @@ class Model:
             container[c.name] = c.as_dict()
             container[c.name]['data'] = self.source.data.copy(deep=False)
             t = birth_time + (c.distance / speed).to(unit=birth_time.unit, copy=False)
-            container[c.name]['data'].coords['tof'] = t
+            container[c.name]['data'].coords['toa'] = t
             if isinstance(c, Detector):
                 container[c.name]['visible_mask'] = initial_mask
                 container[c.name]['data'].masks['blocked_by_others'] = ~initial_mask

--- a/src/tof/reading.py
+++ b/src/tof/reading.py
@@ -104,7 +104,7 @@ def _field_to_string(field: ReadingData) -> str:
 class ReadingField:
     """
     Contains the data for the visible neutrons of a given field.
-    Possible fields are ``tofs``, ``wavelengths``, ``birth_times``, and ``speeds``.
+    Possible fields are ``toas``, ``wavelengths``, ``birth_times``, and ``speeds``.
     In the case of a :class:`Chopper`, this also contains the data for the blocked
     neutrons.
 
@@ -200,7 +200,7 @@ class ComponentReading:
 
     def plot(self, bins: int = 300) -> Plot:
         """
-        Plot both the tof and wavelength data side by side.
+        Plot both the toa and wavelength data side by side.
 
         Parameters
         ----------
@@ -208,7 +208,7 @@ class ComponentReading:
             Number of bins to use for histogramming the neutrons.
         """
         fig, ax = plt.subplots(1, 2)
-        self.tofs.plot(bins=bins, ax=ax[0])
+        self.toas.plot(bins=bins, ax=ax[0])
         self.wavelengths.plot(bins=bins, ax=ax[1])
         size = fig.get_size_inches()
         fig.set_size_inches(size[0] * 2, size[1])

--- a/src/tof/result.py
+++ b/src/tof/result.py
@@ -41,7 +41,7 @@ def _make_reading_data(component, dim, is_chopper=False):
 
 def _add_rays(
     ax: plt.Axes,
-    tofs: sc.Variable,
+    toas: sc.Variable,
     birth_times: sc.Variable,
     distances: sc.Variable,
     cbar: bool = True,
@@ -50,7 +50,7 @@ def _add_rays(
     wmax: Optional[sc.Variable] = None,
 ):
     x0 = birth_times.values.reshape(-1, 1)
-    x1 = tofs.values.reshape(-1, 1)
+    x1 = toas.values.reshape(-1, 1)
     y0 = np.zeros(x0.size).reshape(-1, 1)
     y1 = distances.values.reshape(-1, 1)
     segments = np.concatenate(
@@ -99,14 +99,14 @@ class Result:
         self._arrival_times = {}
         self._choppers = {}
         fields = {
-            'tofs': 'tof',
+            'toas': 'toa',
             'wavelengths': 'wavelength',
             'birth_times': 'time',
             'speeds': 'speed',
         }
         for name, chopper in choppers.items():
             self._masks[name] = chopper['visible_mask']
-            self._arrival_times[name] = chopper['data'].coords['tof']
+            self._arrival_times[name] = chopper['data'].coords['toa']
             self._choppers[name] = ChopperReading(
                 distance=chopper['distance'],
                 name=chopper['name'],
@@ -126,7 +126,7 @@ class Result:
         self._detectors = {}
         for name, det in detectors.items():
             self._masks[name] = det['visible_mask']
-            self._arrival_times[name] = det['data'].coords['tof']
+            self._arrival_times[name] = det['data'].coords['toa']
             self._detectors[name] = DetectorReading(
                 distance=det['distance'],
                 name=det['name'],
@@ -177,11 +177,11 @@ class Result:
     ):
         da = furthest_detector.data['pulse', pulse_index]
         visible = da[~da.masks['blocked_by_others']]
-        tofs = visible.coords['tof']
-        if (max_rays <= 0) or (len(tofs) == 0):
+        toas = visible.coords['toa']
+        if (max_rays <= 0) or (len(toas) == 0):
             return
-        if (max_rays is not None) and (len(tofs) > max_rays):
-            inds = np.random.choice(len(tofs), size=max_rays, replace=False)
+        if (max_rays is not None) and (len(toas) > max_rays):
+            inds = np.random.choice(len(toas), size=max_rays, replace=False)
         else:
             inds = slice(None)
         birth_times = visible.coords['time'][inds]
@@ -189,7 +189,7 @@ class Result:
         distances = furthest_detector.distance.broadcast(sizes=birth_times.sizes)
         _add_rays(
             ax=ax,
-            tofs=tofs[inds],
+            toas=toas[inds],
             birth_times=birth_times,
             distances=distances,
             cbar=cbar,
@@ -221,7 +221,7 @@ class Result:
             key=lambda c: c.distance.value,
         )
         dim = 'component'
-        tofs = sc.concat(
+        toas = sc.concat(
             [
                 self._arrival_times[comp.name][slc][inv_mask][inds]
                 for comp in components
@@ -242,7 +242,7 @@ class Result:
         diff.unit = ''
         _add_rays(
             ax=ax,
-            tofs=(tofs * diff).max(dim=dim),
+            toas=(toas * diff).max(dim=dim),
             birth_times=birth_times,
             distances=(distances * diff).max(dim=dim),
         )
@@ -314,13 +314,13 @@ class Result:
             )
             self._plot_pulse(pulse_index=i, ax=ax)
 
-        det_data = furthest_detector.tofs.visible.data
+        det_data = furthest_detector.toas.visible.data
         if sum(da.sum().value for da in det_data.values()) > 0:
-            times = (da.coords['tof'].max() for da in det_data.values())
+            times = (da.coords['toa'].max() for da in det_data.values())
         else:
             times = (ch.close_times.max() for ch in self._choppers.values())
-        tof_max = reduce(max, times).value
-        dx = 0.05 * tof_max
+        toa_max = reduce(max, times).value
+        dx = 0.05 * toa_max
         # Plot choppers
         for ch in self._choppers.values():
             x0 = ch.open_times.values
@@ -332,25 +332,25 @@ class Result:
             x = np.concatenate(
                 ([[0]] if x[0] > 0 else [x[0:1]])
                 + [x]
-                + ([[tof_max + dx]] if x[-1] < tof_max else [])
+                + ([[toa_max + dx]] if x[-1] < toa_max else [])
             )
             y = np.full_like(x, ch.distance.value)
             y[2::3] = None
             ax.plot(x, y, color="k")
             ax.text(
-                tof_max, ch.distance.value, ch.name, ha="right", va="bottom", color="k"
+                toa_max, ch.distance.value, ch.name, ha="right", va="bottom", color="k"
             )
 
         # Plot detectors
         for det in self._detectors.values():
-            ax.plot([0, tof_max], [det.distance.value] * 2, color="gray", lw=3)
+            ax.plot([0, toa_max], [det.distance.value] * 2, color="gray", lw=3)
             ax.text(
                 0, det.distance.value, det.name, ha="left", va="bottom", color="gray"
             )
 
         ax.set_xlabel("Time-of-flight (us)")
         ax.set_ylabel("Distance (m)")
-        ax.set_xlim(0 - dx, tof_max + dx)
+        ax.set_xlim(0 - dx, toa_max + dx)
         if figsize is None:
             inches = fig.get_size_inches()
             fig.set_size_inches(
@@ -370,10 +370,10 @@ class Result:
             f"{source_sizes[other_dim]} neutrons per pulse.\n  Choppers:\n"
         )
         for name, ch in self._choppers.items():
-            out += f"    {name}: {ch.tofs._repr_string_body()}\n"
+            out += f"    {name}: {ch.toas._repr_string_body()}\n"
         out += "  Detectors:\n"
         for name, det in self._detectors.items():
-            out += f"    {name}: {det.tofs._repr_string_body()}\n"
+            out += f"    {name}: {det.toas._repr_string_body()}\n"
         return out
 
     def __str__(self) -> str:

--- a/src/tof/utils.py
+++ b/src/tof/utils.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
 
 from dataclasses import dataclass
 

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -47,22 +47,22 @@ def test_one_chopper_one_opening():
     res = model.run()
 
     key = 'pulse:0'
-    visible = res.choppers['chopper'].tofs.visible.data[key]
-    blocked = res.choppers['chopper'].tofs.blocked.data[key]
+    visible = res.choppers['chopper'].toas.visible.data[key]
+    blocked = res.choppers['chopper'].toas.blocked.data[key]
 
     assert len(visible) == 1
     assert len(blocked) == 2
     assert sc.isclose(
-        visible.coords['tof'][0],
+        visible.coords['toa'][0],
         (0.5 * (topen + tclose)).to(unit='us'),
     )
-    assert sc.isclose(blocked.coords['tof'][0], (0.9 * topen).to(unit='us'))
-    assert sc.isclose(blocked.coords['tof'][1], (1.1 * tclose).to(unit='us'))
+    assert sc.isclose(blocked.coords['toa'][0], (0.9 * topen).to(unit='us'))
+    assert sc.isclose(blocked.coords['toa'][1], (1.1 * tclose).to(unit='us'))
 
-    det = res.detectors['detector'].tofs.visible.data[key]
+    det = res.detectors['detector'].toas.visible.data[key]
     assert len(det) == 1
     assert sc.isclose(
-        det.coords['tof'][0],
+        det.coords['toa'][0],
         (
             source.data.coords['wavelength']['pulse', 0][1]
             * detector.distance
@@ -111,37 +111,37 @@ def test_two_choppers_one_opening():
     res = model.run()
 
     key = 'pulse:0'
-    ch1_tofs = res.choppers['chopper1'].tofs.data
-    ch2_tofs = res.choppers['chopper2'].tofs.data
+    ch1_toas = res.choppers['chopper1'].toas.data
+    ch2_toas = res.choppers['chopper2'].toas.data
     wavs = source.data.coords['wavelength']['pulse', 0]
-    det = res.detectors['detector'].tofs.visible.data[key]
+    det = res.detectors['detector'].toas.visible.data[key]
 
-    assert len(ch1_tofs['visible'][key]) == 2
-    assert len(ch1_tofs['blocked'][key]) == 1
+    assert len(ch1_toas['visible'][key]) == 2
+    assert len(ch1_toas['blocked'][key]) == 1
     assert sc.isclose(
-        ch1_tofs['visible'][key].coords['tof'][0], (1.5 * topen).to(unit='us')
+        ch1_toas['visible'][key].coords['toa'][0], (1.5 * topen).to(unit='us')
     )
     assert sc.isclose(
-        ch1_tofs['visible'][key].coords['tof'][1],
+        ch1_toas['visible'][key].coords['toa'][1],
         (0.5 * (topen + tclose)).to(unit='us'),
     )
     assert sc.isclose(
-        ch1_tofs['blocked'][key].coords['tof'][0], (1.1 * tclose).to(unit='us')
+        ch1_toas['blocked'][key].coords['toa'][0], (1.1 * tclose).to(unit='us')
     )
-    assert len(ch2_tofs['visible'][key]) == 1
+    assert len(ch2_toas['visible'][key]) == 1
     # Blocks only one neutron, the other is blocked by chopper1
-    assert len(ch2_tofs['blocked'][key]) == 1
+    assert len(ch2_toas['blocked'][key]) == 1
     assert sc.isclose(
-        ch2_tofs['visible'][key].coords['tof'][0],
+        ch2_toas['visible'][key].coords['toa'][0],
         (wavs[1] * chopper2.distance * tof.utils.m_over_h).to(unit='us'),
     )
     assert sc.isclose(
-        ch2_tofs['blocked'][key].coords['tof'][0],
+        ch2_toas['blocked'][key].coords['toa'][0],
         (wavs[0] * chopper2.distance * tof.utils.m_over_h).to(unit='us'),
     )
     assert len(det) == 1
     assert sc.isclose(
-        det.coords['tof'][0],
+        det.coords['toa'][0],
         (wavs[1] * detector.distance * tof.utils.m_over_h).to(unit='us'),
     )
 
@@ -195,11 +195,11 @@ def test_two_choppers_one_and_two_openings():
     res = model.run()
 
     key = 'pulse:0'
-    assert len(res.choppers['chopper1'].tofs.visible.data[key]) == 5
-    assert len(res.choppers['chopper1'].tofs.blocked.data[key]) == 2
-    assert len(res.choppers['chopper2'].tofs.visible.data[key]) == 2
-    assert len(res.choppers['chopper2'].tofs.blocked.data[key]) == 3
-    assert len(res.detectors['detector'].tofs.visible.data[key]) == 2
+    assert len(res.choppers['chopper1'].toas.visible.data[key]) == 5
+    assert len(res.choppers['chopper1'].toas.blocked.data[key]) == 2
+    assert len(res.choppers['chopper2'].toas.visible.data[key]) == 2
+    assert len(res.choppers['chopper2'].toas.blocked.data[key]) == 3
+    assert len(res.detectors['detector'].toas.visible.data[key]) == 2
 
 
 def test_neutron_conservation():
@@ -230,8 +230,8 @@ def test_neutron_conservation():
     res = model.run()
 
     key = 'pulse:0'
-    ch1 = res.choppers['chopper1'].tofs.data
-    ch2 = res.choppers['chopper2'].tofs.data
+    ch1 = res.choppers['chopper1'].toas.data
+    ch2 = res.choppers['chopper2'].toas.data
 
     assert (ch1['visible'][key].sum() + ch1['blocked'][key].sum()).value == N
     assert sc.identical(
@@ -239,7 +239,7 @@ def test_neutron_conservation():
         ch1['visible'][key].sum(),
     )
     assert sc.identical(
-        res.detectors['detector'].tofs.data['visible'][key].sum(),
+        res.detectors['detector'].toas.data['visible'][key].sum(),
         ch2['visible'][key].sum(),
     )
 

--- a/tests/result_test.py
+++ b/tests/result_test.py
@@ -108,8 +108,8 @@ def test_chopper_results_are_read_only(chopper, model):
 
     # Check that basic properties are accessible
     key = 'pulse:0'
-    assert len(ch.tofs.visible.data[key]) == 1
-    assert len(ch.tofs.blocked.data[key]) == 2
+    assert len(ch.toas.visible.data[key]) == 1
+    assert len(ch.toas.blocked.data[key]) == 2
     assert sc.identical(ch.distance, chopper.distance)
     assert sc.identical(ch.phase, chopper.phase)
     # Check that values cannot be overwritten
@@ -118,7 +118,7 @@ def test_chopper_results_are_read_only(chopper, model):
     with pytest.raises(FrozenInstanceError, match='cannot assign to field'):
         ch.frequency = 21.0 * Hz
     with pytest.raises(FrozenInstanceError, match='cannot assign to field'):
-        ch.tofs = [1, 2, 3, 4, 5]
+        ch.toas = [1, 2, 3, 4, 5]
     # Check that choppers cannot be added or removed
     with pytest.raises(TypeError, match='object does not support item assignment'):
         res.choppers['chopper2'] = chopper
@@ -131,7 +131,7 @@ def test_detector_results_are_read_only(detector, model):
     det = res.detectors['detector']
 
     # Check that basic properties are accessible
-    assert len(det.tofs.visible.data['pulse:0']) == 1
+    assert len(det.toas.visible.data['pulse:0']) == 1
     assert sc.identical(det.distance, detector.distance)
     # Check that values cannot be overwritten
     with pytest.raises(FrozenInstanceError, match='cannot assign to field'):
@@ -153,13 +153,13 @@ def test_component_results_data_access(chopper, detector, multi_pulse_source):
     ch = res.choppers['chopper']
     det = res.detectors['detector']
 
-    for field in ('tofs', 'wavelengths', 'birth_times', 'speeds'):
+    for field in ('toas', 'wavelengths', 'birth_times', 'speeds'):
         assert 'visible' in getattr(ch, field).data
         assert 'blocked' in getattr(ch, field).data
         assert 'visible' in getattr(det, field).data
         assert 'blocked' not in getattr(det, field).data
 
-    assert list(ch.tofs.visible.data.keys()) == [f'pulse:{i}' for i in range(3)]
+    assert list(ch.toas.visible.data.keys()) == [f'pulse:{i}' for i in range(3)]
     assert list(det.wavelengths.visible.data.keys()) == [f'pulse:{i}' for i in range(3)]
 
 
@@ -170,11 +170,11 @@ def test_component_data_slicing(chopper, detector, multi_pulse_source):
     res = model.run()
     ch = res.choppers['chopper']
 
-    tofs = ch.tofs[0]
-    assert 'visible' in tofs.data
-    assert 'blocked' in tofs.data
-    vis = ch.tofs.visible[1]
-    assert sc.identical(vis.data['pulse:1'], ch.tofs.visible.data['pulse:1'])
+    toas = ch.toas[0]
+    assert 'visible' in toas.data
+    assert 'blocked' in toas.data
+    vis = ch.toas.visible[1]
+    assert sc.identical(vis.data['pulse:1'], ch.toas.visible.data['pulse:1'])
 
 
 def test_component_results_data_slice_range(chopper, detector, multi_pulse_source):
@@ -184,12 +184,12 @@ def test_component_results_data_slice_range(chopper, detector, multi_pulse_sourc
     res = model.run()
     ch = res.choppers['chopper']
 
-    tofs = ch.tofs[0:2]
-    assert 'visible' in tofs.data
-    assert 'blocked' in tofs.data
-    assert 'pulse:0' in tofs.data['visible']
-    assert 'pulse:1' in tofs.data['visible']
-    assert 'pulse:2' not in tofs.data['visible']
+    toas = ch.toas[0:2]
+    assert 'visible' in toas.data
+    assert 'blocked' in toas.data
+    assert 'pulse:0' in toas.data['visible']
+    assert 'pulse:1' in toas.data['visible']
+    assert 'pulse:2' not in toas.data['visible']
 
 
 def test_component_results_data_slice_negative_index(
@@ -201,12 +201,12 @@ def test_component_results_data_slice_negative_index(
     res = model.run()
     ch = res.choppers['chopper']
 
-    tofs = ch.tofs[0:-1]
-    assert 'visible' in tofs.data
-    assert 'blocked' in tofs.data
-    assert 'pulse:0' in tofs.data['visible']
-    assert 'pulse:1' in tofs.data['visible']
-    assert 'pulse:2' not in tofs.data['visible']
+    toas = ch.toas[0:-1]
+    assert 'visible' in toas.data
+    assert 'blocked' in toas.data
+    assert 'pulse:0' in toas.data['visible']
+    assert 'pulse:1' in toas.data['visible']
+    assert 'pulse:2' not in toas.data['visible']
 
 
 def test_component_results_data_slice_step(chopper, detector, multi_pulse_source):
@@ -216,12 +216,12 @@ def test_component_results_data_slice_step(chopper, detector, multi_pulse_source
     res = model.run()
     ch = res.choppers['chopper']
 
-    tofs = ch.tofs[::2]
-    assert 'visible' in tofs.data
-    assert 'blocked' in tofs.data
-    assert 'pulse:0' in tofs.data['visible']
-    assert 'pulse:1' not in tofs.data['visible']
-    assert 'pulse:2' in tofs.data['visible']
+    toas = ch.toas[::2]
+    assert 'visible' in toas.data
+    assert 'blocked' in toas.data
+    assert 'pulse:0' in toas.data['visible']
+    assert 'pulse:1' not in toas.data['visible']
+    assert 'pulse:2' in toas.data['visible']
 
 
 def test_result_plot_does_not_raise():
@@ -271,13 +271,13 @@ def test_component_repr_does_not_raise():
 def test_componentdata_repr_does_not_raise():
     model = make_ess_model()
     res = model.run()
-    assert repr(res.choppers['chopper'].tofs) is not None
+    assert repr(res.choppers['chopper'].toas) is not None
     assert repr(res.detectors['detector'].wavelengths) is not None
 
 
 def test_data_repr_does_not_raise():
     model = make_ess_model()
     res = model.run()
-    assert repr(res.choppers['chopper'].tofs.visible) is not None
-    assert repr(res.choppers['chopper'].tofs.blocked) is not None
+    assert repr(res.choppers['chopper'].toas.visible) is not None
+    assert repr(res.choppers['chopper'].toas.blocked) is not None
     assert repr(res.detectors['detector'].wavelengths.visible) is not None


### PR DESCRIPTION
The time-of-arrival of a neutron at the detector is commonly named time-of-flight or `tof`.

This name is however misleading because it is not necessarily the time the neutron spent in-flight,
since that also depends on the birth time of the neutron.

Only the arrival time is known at a neutron beamline,
and there is thus an inherent uncertainty in the birth time as neutrons can originate from any part of the pulse.
This is especially true at long-pulse neutron sources such as ESS.

We rename `tof` to `toa` in this PR to remove confusion around the definition of time-of-flight.
We keep the `tofs` properties and `tof` coordinate, and add deprecation warnings when they are accessed.