### PR TITLE
Make facility information for accessible

### DIFF
--- a/src/tof/__init__.py
+++ b/src/tof/__init__.py
@@ -1,11 +1,27 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 
-# flake8: noqa F401
-
 from .chopper import AntiClockwise, Chopper, ChopperReading, Clockwise
 from .detector import Detector, DetectorReading
+from .facilities import library as facilities
 from .model import Model
 from .reading import ComponentReading, ReadingData, ReadingField
 from .result import Result
 from .source import Source, SourceParameters
+
+__all__ = [
+    'AntiClockwise',
+    'Chopper',
+    'ChopperReading',
+    'Clockwise',
+    'ComponentReading',
+    'Detector',
+    'DetectorReading',
+    'facilities',
+    'Model',
+    'ReadingData',
+    'ReadingField',
+    'Result',
+    'Source',
+    'SourceParameters',
+]

--- a/src/tof/facilities/__init__.py
+++ b/src/tof/facilities/__init__.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 
-# flake8: noqa F401
+from .ess_pulse import pulse as esspulse
 
-from .ess_pulse import pulse as ess
+library = {'ess': esspulse}
+
+__all__ = ['library']

--- a/src/tof/facilities/ess_pulse.py
+++ b/src/tof/facilities/ess_pulse.py
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 
+"""
+The data here was obtained from the McStas model of the ESS moderator.
+"""
+
 import scipp as sc
 
 from ..utils import FacilityPulse

--- a/src/tof/facilities/ess_pulse.py
+++ b/src/tof/facilities/ess_pulse.py
@@ -3,6 +3,7 @@
 
 """
 The data here was obtained from the McStas model of the ESS moderator.
+See https://www2.mcstas.org/download/components/3.4_current/sources/ESS_butterfly.html.
 """
 
 import scipp as sc

--- a/src/tof/source.py
+++ b/src/tof/source.py
@@ -10,7 +10,7 @@ import plopp as pp
 import scipp as sc
 from scipp.scipy.interpolate import interp1d
 
-from . import facilities
+from .facilities import library as facilities
 from .utils import Plot, wavelength_to_speed
 
 TIME_UNIT = "us"
@@ -152,9 +152,7 @@ def _make_pulses(
         unit=TIME_UNIT,
     ).fold(dim=dim, sizes={"pulse": pulses, dim: neutrons}) + (
         sc.arange("pulse", pulses) / frequency
-    ).to(
-        unit=TIME_UNIT, copy=False
-    )
+    ).to(unit=TIME_UNIT, copy=False)
 
     wavelength = sc.array(
         dims=[dim],
@@ -208,7 +206,7 @@ class Source:
         self.data = None
 
         if facility is not None:
-            facility_params = getattr(facilities, self.facility)
+            facility_params = facilities[self.facility]
             self.frequency = facility_params.frequency
             pulse_params = _make_pulses(
                 neutrons=self.neutrons,

--- a/src/tof/source.py
+++ b/src/tof/source.py
@@ -152,7 +152,9 @@ def _make_pulses(
         unit=TIME_UNIT,
     ).fold(dim=dim, sizes={"pulse": pulses, dim: neutrons}) + (
         sc.arange("pulse", pulses) / frequency
-    ).to(unit=TIME_UNIT, copy=False)
+    ).to(
+        unit=TIME_UNIT, copy=False
+    )
 
     wavelength = sc.array(
         dims=[dim],


### PR DESCRIPTION
With this, we can now access the properties of the facility pulse (time and wavelength profiles) without creating a source with neutrons (which can be expensive).

```Py
import tof
tof.facilities['ess']
```
```
FacilityPulse(time=<scipp.DataArray>
Dimensions: Sizes[time:201, ]
Coordinates:
* time                      float64              [s]  (time)  [1.24378e-05, 3.73134e-05, ..., 0.00496269, 0.00498756]
Data:
                            float64  [dimensionless]  (time)  [0.000335837, 0.000711463, ..., 1.1283e-05, 1.05061e-05]

, wavelength=<scipp.DataArray>
Dimensions: Sizes[wavelength:101, ]
Coordinates:
* wavelength                float64             [Å]  (wavelength)  [0.198515, 0.395545, ..., 19.7045, 19.9015]
Data:
                            float64  [dimensionless]  (wavelength)  [0.0247911, 0.0315395, ..., 2.57594e-05, 2.41536e-05]

, frequency=<scipp.Variable> ()    float64             [Hz]  14)
```