### PR TITLE
Do not group nxevent_data by pulse

### DIFF
--- a/src/tof/result.py
+++ b/src/tof/result.py
@@ -427,8 +427,8 @@ class Result:
         ) % period.to(unit=dt.unit)
         out = (
             event_data.drop_coords(['tof', 'speed', 'time', 'wavelength'])
-            .group('distance', 'event_time_zero')
-            .rename_dims(event_time_zero='pulse')
-        ).rename_dims(distance='detector_number')
+            .group('distance')
+            .rename_dims(distance='detector_number')
+        )
         out.coords['Ltotal'] = out.coords.pop('distance')
         return out

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -421,7 +421,8 @@ def test_to_nxevent_data():
     for key, npulses in zip(('monitor', 'detector'), (1, 2)):
         nxevent_data = res.to_nxevent_data(key)
         assert sc.identical(res['monitor'].data.sum().data, nxevent_data.sum().data)
-        assert nxevent_data.sizes['pulse'] == npulses
+        grouped = nxevent_data.group('event_time_zero')
+        assert grouped.sizes['event_time_zero'] == npulses
         assert nxevent_data.bins.concat().value.coords[
             'event_time_offset'
         ].min() >= sc.scalar(0.0, unit='us')
@@ -431,4 +432,4 @@ def test_to_nxevent_data():
 
     # Test when we include all detectors at once
     nxevent_data = res.to_nxevent_data()
-    assert nxevent_data.sizes == {'detector_number': 2, 'pulse': 2}
+    assert nxevent_data.sizes == {'detector_number': 2}


### PR DESCRIPTION
This resembles more the nxevent data as they are read in by scippnexus: they are grouped by `detector_number`, but each event still has individual `event_time_zero`.