### PR TITLE
Skip linkcheck to get the docs pages published on github pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -62,8 +62,8 @@ jobs:
         if: ${{ inputs.version != '' }}
       - run: tox -e docs
         if: ${{ inputs.version == '' }}
-      - run: tox -e linkcheck
-        if: ${{ inputs.linkcheck }}
+      # - run: tox -e linkcheck
+      #   if: ${{ inputs.linkcheck }}
       - uses: actions/upload-artifact@v4
         id: artifact-upload-step
         with:


### PR DESCRIPTION
The link check fails as it assumes that the docs are already deployed on github, so need to first skip it once to populate the gh-pages branch.