### PR TITLE
Add option to specify chopper name when creating from_diskchopper or from_nexus

### DIFF
--- a/src/tof/chopper.py
+++ b/src/tof/chopper.py
@@ -223,7 +223,9 @@ class Chopper:
         )
 
     @classmethod
-    def from_diskchopper(cls, disk_chopper: DiskChopper) -> Chopper:
+    def from_diskchopper(
+        cls, disk_chopper: DiskChopper, name: str | None = None
+    ) -> Chopper:
         """
         Create a Chopper from a scippneutron DiskChopper.
 
@@ -249,6 +251,12 @@ class Chopper:
 
         distance = disk_chopper.axle_position.fields.z
         freq = abs(disk_chopper.frequency)
+        if name is None:
+            name = (
+                f"Chopper@{distance.value:.1f}{distance.unit}_"
+                f"{int(freq.value)}{freq.unit}"
+            )
+
         return cls(
             frequency=freq,
             direction=AntiClockwise
@@ -260,14 +268,11 @@ class Chopper:
             if disk_chopper.frequency.value > 0.0
             else -disk_chopper.phase,
             distance=distance,
-            name=(
-                f"Chopper@{distance.value:.1f}{distance.unit}_"
-                f"{int(freq.value)}{freq.unit}"
-            ),
+            name=name,
         )
 
     @classmethod
-    def from_nexus(cls, nexus_chopper) -> Chopper:
+    def from_nexus(cls, nexus_chopper, name: str | None = None) -> Chopper:
         """
         Create a Chopper from a NeXus chopper group.
 
@@ -291,8 +296,15 @@ class Chopper:
         ... }
         >>> chopper = tof.Chopper.from_nexus(nexus_chopper)
         """
+
         distance = nexus_chopper['position'].fields.z
         freq = abs(nexus_chopper['rotation_speed'])
+        if name is None:
+            name = (
+                f"Chopper@{distance.value:.1f}{distance.unit}_"
+                f"{int(freq.value)}{freq.unit}"
+            )
+
         return cls(
             frequency=freq,
             direction=AntiClockwise
@@ -304,10 +316,7 @@ class Chopper:
             if nexus_chopper['rotation_speed'].value > 0.0
             else -nexus_chopper['phase'],
             distance=distance,
-            name=(
-                f"Chopper@{distance.value:.1f}{distance.unit}_"
-                f"{int(freq.value)}{freq.unit}",
-            ),
+            name=name,
         )
 
     def to_diskchopper(self) -> DiskChopper:

--- a/tests/chopper_test.py
+++ b/tests/chopper_test.py
@@ -528,6 +528,20 @@ def test_from_diskchopper_clockwise():
     assert chopper.direction == tof.Clockwise
 
 
+def test_from_diskchopper_with_name():
+    disk_chopper = DiskChopper(
+        axle_position=sc.vector([0.0, 0.0, 2.0], unit='m'),
+        frequency=sc.scalar(12.0, unit='Hz'),
+        beam_position=sc.scalar(45.0, unit='deg'),
+        phase=sc.scalar(20.0, unit='deg'),
+        slit_begin=sc.array(dims=['slit'], values=[0.0, 124.0], unit='deg'),
+        slit_end=sc.array(dims=['slit'], values=[60.0, 126.0], unit='deg'),
+    )
+
+    chopper = tof.Chopper.from_diskchopper(disk_chopper, name="TestChopper")
+    assert chopper.name == "TestChopper"
+
+
 def test_to_diskchopper():
     chopper = tof.Chopper(
         frequency=12.0 * Hz,


### PR DESCRIPTION
Can now do
```Py
chopper = tof.Chopper.from_diskchopper(disk_chopper, name="TestChopper")
```