### PR TITLE
Use a spread width consistent with a potentially cropped wavelength range

### DIFF
--- a/src/tof/source.py
+++ b/src/tof/source.py
@@ -115,8 +115,10 @@ def _make_pulses(
     # prohibitively slow.
     # See https://docs.scipy.org/doc/scipy/tutorial/stats/sampling.html for more
     # information.
-    dt = 0.5 * (tmax - tmin).value / (p.sizes[t_dim] - 1)
-    dw = 0.5 * (wmax - wmin).value / (p.sizes[w_dim] - 1)
+    tsel = (p.coords[t_dim] >= tmin) & (p.coords[t_dim] <= tmax)
+    wsel = (p.coords[w_dim] >= wmin) & (p.coords[w_dim] <= wmax)
+    dt = 0.5 * (tmax - tmin).value / (p[tsel].sizes[t_dim] - 1)
+    dw = 0.5 * (wmax - wmin).value / (p[wsel].sizes[w_dim] - 1)
 
     # Because of the added noise, some values end up being outside the specified range
     # for the birth times and wavelengths. Using naive clipping leads to pile-up on the


### PR DESCRIPTION
Bug introduced in #106 when the `sampling` was removed. Were were using the number of points in the full wavelength range. This meant that for a small wavelength range, the spread width was the spacing between point divided by the total size of the wavelength dimension.

We now use the size of the cropped wavelength range instead.

Example: this code snippet
```Py
import scipp as sc
import plopp as pp
import tof

wavelength_min = sc.scalar(1.8, unit='angstrom')
wavelength_max = sc.scalar(3.55, unit='angstrom')
source = tof.Source(
    facility="ess",
    pulses=1,
    wmin=wavelength_min,
    wmax=wavelength_max,
    neutrons=1_000_000
)
cropped_hist = source.data.hist(wavelength=1000)['wavelength', wavelength_min:wavelength_max].plot(title="Cropped Range Source")
source = tof.Source(
    facility="ess",
    pulses=1,
    neutrons=1_000_000
)
full_range_hist = source.data.hist(wavelength=1000)['wavelength', wavelength_min:wavelength_max].plot(title='Full Range, Cropped Later')
cropped_hist + full_range_hist
```
would give
<img width="1174" height="392" alt="Screenshot_20251208_152231" src="https://github.com/user-attachments/assets/8e06ac11-27e6-4ed2-8551-7a2ded040776" />

After the fix, it looks close to what it did before with the sampling:
<img width="1174" height="392" alt="Screenshot_20251208_152240" src="https://github.com/user-attachments/assets/dddc444e-724c-470a-80e7-4dfb2a62ec73" />


Note that this does not give exactly the same results as before `25.12.0`. It just uses the distribution it's given. So if the selected wavelength range is very small, the results will start looking more like a step function, while in older versions some internal linear interpolation was being done behind the scenes. This was maybe what the user wanted, but maybe not. So instead of doing it silently in the background, we now require the users to manually interpolate before sending the probability arrays to the source, if that is what they want.