### PR TITLE
adding kf/ki factor to the cooridnates for InelasticSample class

### DIFF
--- a/src/tof/inelastic.py
+++ b/src/tof/inelastic.py
@@ -41,7 +41,7 @@ class InelasticSampleReading(ComponentReading):
         self, val: int | slice | tuple[str, int | slice]
     ) -> InelasticSampleReading:
         if isinstance(val, int):
-            val = ("pulse", val)
+            val = ('pulse', val)
         return replace(self, data=self.data[val])
 
     def plot_on_time_distance_diagram(self, ax, tmax) -> None:
@@ -98,7 +98,7 @@ class InelasticSample(Component):
         """
         Return the inelastic sample as a dictionary.
         """
-        return {"distance": self.distance, "name": self.name, "func": self.func}
+        return {'distance': self.distance, 'name': self.name, 'func': self.func}
 
     @classmethod
     def from_json(cls, name: str, params: dict) -> InelasticSample:

--- a/src/tof/inelastic.py
+++ b/src/tof/inelastic.py
@@ -41,7 +41,7 @@ class InelasticSampleReading(ComponentReading):
         self, val: int | slice | tuple[str, int | slice]
     ) -> InelasticSampleReading:
         if isinstance(val, int):
-            val = ('pulse', val)
+            val = ("pulse", val)
         return replace(self, data=self.data[val])
 
     def plot_on_time_distance_diagram(self, ax, tmax) -> None:
@@ -98,7 +98,7 @@ class InelasticSample(Component):
         """
         Return the inelastic sample as a dictionary.
         """
-        return {'distance': self.distance, 'name': self.name, 'func': self.func}
+        return {"distance": self.distance, "name": self.name, "func": self.func}
 
     @classmethod
     def from_json(cls, name: str, params: dict) -> InelasticSample:
@@ -152,6 +152,8 @@ class InelasticSample(Component):
         w_final = energy_to_wavelength(final_energy, unit=incident_wavelength.unit)
 
         out = neutrons.assign_coords(
-            wavelength=w_final, speed=wavelength_to_speed(w_final)
+            wavelength=w_final,
+            speed=wavelength_to_speed(w_final),
+            kf_over_ki=sc.sqrt(final_energy / incident_energy),
         )
         return out, self.as_readonly(out)


### PR DESCRIPTION
In the elastic scattering process, the double differential cross section if proportional to kf/ki*S(Q,E). Right now, the InelasticSample keeps the information about the final energy/wavelength only and discard the information about the initial wavelength/energy. Once it happens, it is impossible to get the information back. I am proposing to add the ratio of kf/ki to the coordinates, which will help with the further calculation of the double differential cross section. 