### PR TITLE
Add high resolution sources for all ESS instruments

### DIFF
--- a/docs/sources.ipynb
+++ b/docs/sources.ipynb
@@ -350,7 +350,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9b7286d3-6275-41c2-a867-e39d5f8292ad",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/sources.ipynb
+++ b/docs/sources.ipynb
@@ -344,10 +344,20 @@
    "source": [
     "## List of available sources/facilities\n",
     "\n",
-    "Here is a list of the currently supported sources, that can be selected via the `facility` argument:\n",
+    "Here is a list of the currently supported sources, that can be selected via the `facility` argument:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b7286d3-6275-41c2-a867-e39d5f8292ad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tof.facilities import source_library\n",
     "\n",
-    "- `'ess'`: the standard ESS source profile, applicable for all ESS instruments\n",
-    "- `'ess-odin'`: a source specific to the ESS Odin instrument, sampled at the location where cold and thermal neutrons are combined (~2.35m away from the surface of the moderator)"
+    "for name, src in source_library.items():\n",
+    "    print(f'{name}:\\n    ', src['description'])"
    ]
   }
  ],

--- a/src/tof/facilities/__init__.py
+++ b/src/tof/facilities/__init__.py
@@ -9,8 +9,8 @@ _source_library = {}
 _source_library.update(ess.sources)
 
 _BASE_URLS = [
-    "https://public.esss.dk/groups/scipp/tof/1/",  # primary: DMSC server
-    "https://github.com/scipp/tof-sources/raw/refs/heads/main/1/",  # fallback: GitHub
+    "https://public.esss.dk/groups/scipp/tof/2/",  # primary: DMSC server
+    "https://github.com/scipp/tof-sources/raw/refs/heads/main/2/",  # fallback: GitHub
 ]
 
 # One registry per mirror URL

--- a/src/tof/facilities/__init__.py
+++ b/src/tof/facilities/__init__.py
@@ -5,8 +5,8 @@ import pooch
 
 from . import ess
 
-_source_library = {}
-_source_library.update(ess.sources)
+source_library = {}
+source_library.update(ess.sources)
 
 _BASE_URLS = [
     "https://public.esss.dk/groups/scipp/tof/2/",  # primary: DMSC server
@@ -19,14 +19,14 @@ _registries = [
         path=pooch.os_cache("tof"),
         base_url=base_url,
         retry_if_failed=2,
-        registry={f["path"]: f["hash"] for f in _source_library.values()},
+        registry={f["path"]: f["hash"] for f in source_library.values()},
     )
     for base_url in _BASE_URLS
 ]
 
 
 def get_source_path(name: str) -> str:
-    path = _source_library[name]["path"]
+    path = source_library[name]["path"]
     last_exc = None
     for registry in _registries:
         try:
@@ -38,4 +38,4 @@ def get_source_path(name: str) -> str:
     ) from last_exc
 
 
-__all__ = ["ess", "get_source_path"]
+__all__ = ["ess", "get_source_path", "source_library"]

--- a/src/tof/facilities/ess/__init__.py
+++ b/src/tof/facilities/ess/__init__.py
@@ -27,70 +27,108 @@ from .magic import magic
 from .odin import odin
 
 sources = {
-    "ess": {"path": "ess/ess.h5", "hash": "md5:4d929bf73ba808f8a63ebaf137e4b2fc"},
+    "ess": {
+        "path": "ess/ess.h5",
+        "hash": "md5:4d929bf73ba808f8a63ebaf137e4b2fc",
+        "description": "The standard ESS source profile, applicable for all ESS "
+        "instruments.",
+    },
     "ess-beer": {
         "path": "ess/ess-beer.h5",
         "hash": "md5:9e4350a13c6f322ebe788ce874787a3b",
+        "description": "A source for the ESS Beer instrument, sampled at the entrance "
+        "of the beam port, 5cm from the surface of the moderator.",
     },
     "ess-bifrost": {
         "path": "ess/ess-bifrost.h5",
         "hash": "md5:83952831dc576124b8a4de6593c09c64",
+        "description": "A source for the ESS Bifrost instrument, sampled at the "
+        "entrance of the beam port, 5cm from the surface of the moderator.",
     },
     "ess-cspec": {
         "path": "ess/ess-cspec.h5",
         "hash": "md5:09e7ed297aefcddc4eb5a63146629b22",
+        "description": "A source for the ESS C-SPEC instrument, sampled at the "
+        "entrance of the beam port, 5cm from the surface of the moderator.",
     },
     "ess-dream": {
         "path": "ess/ess-dream.h5",
         "hash": "md5:ddd18500e4bd627fb6fca7d010bec019",
+        "description": "A source for the ESS Dream instrument, sampled at the "
+        "entrance of the beam port, 5cm from the surface of the moderator.",
     },
     "ess-estia": {
         "path": "ess/ess-estia.h5",
         "hash": "md5:2c6a0af4559be482bb30c67131d25be4",
+        "description": "A source for the ESS Estia instrument, sampled at the "
+        "entrance of the beam port, 5cm from the surface of the moderator.",
     },
     "ess-freia": {
         "path": "ess/ess-freia.h5",
         "hash": "md5:58fd7a0c720f4ce17a1d5713b02d9f96",
+        "description": "A source for the ESS Freia instrument, sampled at the "
+        "entrance of the beam port, 5cm from the surface of the moderator.",
     },
     "ess-heimdal": {
         "path": "ess/ess-heimdal.h5",
         "hash": "md5:40925e3267acaa8b6efcd05b67881107",
+        "description": "A source for the ESS Heimdal instrument, sampled at the "
+        "entrance of the beam port, 5cm from the surface of the moderator.",
     },
     "ess-loki": {
         "path": "ess/ess-loki.h5",
         "hash": "md5:6727cd93ea8775cd2ac6d8ce3c3446e8",
+        "description": "A source for the ESS Loki instrument, sampled at the "
+        "entrance of the beam port, 5cm from the surface of the moderator.",
     },
     "ess-magic": {
         "path": "ess/ess-magic.h5",
         "hash": "md5:de2989fd6123f3d4cda6a1c2c13a0e49",
+        "description": "A source for the ESS Magic instrument, sampled at the "
+        "entrance of the beam port, 5cm from the surface of the moderator.",
     },
     "ess-miracles": {
         "path": "ess/ess-miracles.h5",
         "hash": "md5:5d33490ae632a1ee33d617f0daf050a7",
+        "description": "A source for the ESS Miracles instrument, sampled at the "
+        "entrance of the beam port, 5cm from the surface of the moderator.",
     },
     "ess-nmx": {
         "path": "ess/ess-nmx.h5",
         "hash": "md5:dca26e529f01b8e8f55b5611802d36a5",
+        "description": "A source for the ESS NMX instrument, sampled at the "
+        "entrance of the beam port, 5cm from the surface of the moderator.",
     },
     "ess-odin": {
         "path": "ess/ess-odin.h5",
         "hash": "md5:4d64102d2a743bd7672967ad0cb94872",
+        "description": "A source for the ESS Odin instrument, sampled at the "
+        "location where cold and thermal neutrons are combined (~2.35m away from the "
+        "surface of the moderator)",
     },
     "ess-skadi": {
         "path": "ess/ess-skadi.h5",
         "hash": "md5:eab4c20f95ed2a63479407a54a01cca9",
+        "description": "A source for the ESS Skadi instrument, sampled at the "
+        "entrance of the beam port, 5cm from the surface of the moderator.",
     },
     "ess-tbl": {
         "path": "ess/ess-tbl.h5",
         "hash": "md5:8af1a26d386f690e89ef23f35daeef13",
+        "description": "A source for the ESS TBL instrument, sampled at the "
+        "entrance of the beam port, 5cm from the surface of the moderator.",
     },
     "ess-trex": {
         "path": "ess/ess-trex.h5",
         "hash": "md5:3f6f77ce4b301867acb334b7378b7fe1",
+        "description": "A source for the ESS Trex instrument, sampled at the "
+        "entrance of the beam port, 5cm from the surface of the moderator.",
     },
     "ess-vespa": {
         "path": "ess/ess-vespa.h5",
         "hash": "md5:eac9c4c4b861090426f0ed3c2e2b479d",
+        "description": "A source for the ESS Vespa instrument, sampled at the "
+        "entrance of the beam port, 5cm from the surface of the moderator.",
     },
 }
 

--- a/src/tof/facilities/ess/__init__.py
+++ b/src/tof/facilities/ess/__init__.py
@@ -27,70 +27,70 @@ from .magic import magic
 from .odin import odin
 
 sources = {
-    "ess": {"path": "ess/ess.h5", "hash": "md5:689630334ae9a7f462f76943740a8ff2"},
+    "ess": {"path": "ess/ess.h5", "hash": "md5:4d929bf73ba808f8a63ebaf137e4b2fc"},
+    "ess-beer": {
+        "path": "ess/ess-beer.h5",
+        "hash": "md5:9e4350a13c6f322ebe788ce874787a3b",
+    },
+    "ess-bifrost": {
+        "path": "ess/ess-bifrost.h5",
+        "hash": "md5:83952831dc576124b8a4de6593c09c64",
+    },
+    "ess-cspec": {
+        "path": "ess/ess-cspec.h5",
+        "hash": "md5:09e7ed297aefcddc4eb5a63146629b22",
+    },
+    "ess-dream": {
+        "path": "ess/ess-dream.h5",
+        "hash": "md5:ddd18500e4bd627fb6fca7d010bec019",
+    },
+    "ess-estia": {
+        "path": "ess/ess-estia.h5",
+        "hash": "md5:2c6a0af4559be482bb30c67131d25be4",
+    },
+    "ess-freia": {
+        "path": "ess/ess-freia.h5",
+        "hash": "md5:58fd7a0c720f4ce17a1d5713b02d9f96",
+    },
+    "ess-heimdal": {
+        "path": "ess/ess-heimdal.h5",
+        "hash": "md5:40925e3267acaa8b6efcd05b67881107",
+    },
+    "ess-loki": {
+        "path": "ess/ess-loki.h5",
+        "hash": "md5:6727cd93ea8775cd2ac6d8ce3c3446e8",
+    },
+    "ess-magic": {
+        "path": "ess/ess-magic.h5",
+        "hash": "md5:de2989fd6123f3d4cda6a1c2c13a0e49",
+    },
+    "ess-miracles": {
+        "path": "ess/ess-miracles.h5",
+        "hash": "md5:5d33490ae632a1ee33d617f0daf050a7",
+    },
+    "ess-nmx": {
+        "path": "ess/ess-nmx.h5",
+        "hash": "md5:dca26e529f01b8e8f55b5611802d36a5",
+    },
     "ess-odin": {
         "path": "ess/ess-odin.h5",
         "hash": "md5:4d64102d2a743bd7672967ad0cb94872",
     },
-    "ess-nmx": {
-        "path": "ess/ess-nmx.h5",
-        "hash": "md5:c8a3d0c6ef17c704c94afc38b031fa60",
-    },
-    "ess-beer": {
-        "path": "ess/ess-beer.h5",
-        "hash": "md5:7d98d4446f53f4c47c3d632ae2f886b7",
-    },
-    "ess-cspec": {
-        "path": "ess/ess-cspec.h5",
-        "hash": "md5:8f8268c3b8ae6219c595b9d099ee632d",
-    },
-    "ess-bifrost": {
-        "path": "ess/ess-bifrost.h5",
-        "hash": "md5:c05b50d2a3a919e10fb0abd44144c83d",
-    },
-    "ess-miracles": {
-        "path": "ess/ess-miracles.h5",
-        "hash": "md5:3760666ce2685ff88bb79cec8d19ef8c",
-    },
-    "ess-magic": {
-        "path": "ess/ess-magic.h5",
-        "hash": "md5:774e99c8130075139b8476a87fb43182",
-    },
-    "ess-trex": {
-        "path": "ess/ess-trex.h5",
-        "hash": "md5:1eb645ec2e71324c2d03a30c4f3525fb",
-    },
-    "ess-heimdal": {
-        "path": "ess/ess-heimdal.h5",
-        "hash": "md5:e95da29df2f478eb7357583b8c388123",
-    },
-    "ess-dream": {
-        "path": "ess/ess-dream.h5",
-        "hash": "md5:0957767f7439f70aaf1abf934d30da07",
-    },
-    "ess-loki": {
-        "path": "ess/ess-loki.h5",
-        "hash": "md5:319936b29e3e8ac70283408950e6195c",
-    },
-    "ess-freia": {
-        "path": "ess/ess-freia.h5",
-        "hash": "md5:cad1a612214d0155b060094b1078f254",
-    },
-    "ess-estia": {
-        "path": "ess/ess-estia.h5",
-        "hash": "md5:a0bdf9e17611a77054686c5041aaae3f",
-    },
     "ess-skadi": {
         "path": "ess/ess-skadi.h5",
-        "hash": "md5:521dc300296db137fa3dd5877882f68c",
-    },
-    "ess-vespa": {
-        "path": "ess/ess-vespa.h5",
-        "hash": "md5:298f599f7dc861d1319748c7ea3c54fc",
+        "hash": "md5:eab4c20f95ed2a63479407a54a01cca9",
     },
     "ess-tbl": {
         "path": "ess/ess-tbl.h5",
-        "hash": "md5:c9db7f205131c4caf491d5951253bea7",
+        "hash": "md5:8af1a26d386f690e89ef23f35daeef13",
+    },
+    "ess-trex": {
+        "path": "ess/ess-trex.h5",
+        "hash": "md5:3f6f77ce4b301867acb334b7378b7fe1",
+    },
+    "ess-vespa": {
+        "path": "ess/ess-vespa.h5",
+        "hash": "md5:eac9c4c4b861090426f0ed3c2e2b479d",
     },
 }
 

--- a/src/tof/facilities/ess/__init__.py
+++ b/src/tof/facilities/ess/__init__.py
@@ -1,15 +1,96 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 
+"""
+Sources for the instruments at the ESS facility.
+
+They were generated using the tools/generate_ess_sources.ipynb notebook.
+
+The following parameters were used:
+
+Source:
+Lmin=0.1, Lmax=20, focus_xw=0.1, focus_yh=0.1, dist=2
+
+Monitor:
+xwidth=1.0, yheight=1.0, restore_neutron=1, l bins=1024, limits=[0.1, 20], t bins=1024,
+limits=[0 0.006], set_AT=0.05, RELATIVE=source
+
+Instrument settings:
+ncount=1.0e10
+
+Gaussian smoothing:
+sigma=2
+"""
+
 from .dream import dream
 from .magic import magic
 from .odin import odin
 
 sources = {
-    "ess": {"path": "ess/ess.h5", "hash": "md5:f382e4a5c2171b4ef2285fb6625544e4"},
+    "ess": {"path": "ess/ess.h5", "hash": "md5:689630334ae9a7f462f76943740a8ff2"},
     "ess-odin": {
         "path": "ess/ess-odin.h5",
         "hash": "md5:4d64102d2a743bd7672967ad0cb94872",
+    },
+    "ess-nmx": {
+        "path": "ess/ess-nmx.h5",
+        "hash": "md5:c8a3d0c6ef17c704c94afc38b031fa60",
+    },
+    "ess-beer": {
+        "path": "ess/ess-beer.h5",
+        "hash": "md5:7d98d4446f53f4c47c3d632ae2f886b7",
+    },
+    "ess-cspec": {
+        "path": "ess/ess-cspec.h5",
+        "hash": "md5:8f8268c3b8ae6219c595b9d099ee632d",
+    },
+    "ess-bifrost": {
+        "path": "ess/ess-bifrost.h5",
+        "hash": "md5:c05b50d2a3a919e10fb0abd44144c83d",
+    },
+    "ess-miracles": {
+        "path": "ess/ess-miracles.h5",
+        "hash": "md5:3760666ce2685ff88bb79cec8d19ef8c",
+    },
+    "ess-magic": {
+        "path": "ess/ess-magic.h5",
+        "hash": "md5:774e99c8130075139b8476a87fb43182",
+    },
+    "ess-trex": {
+        "path": "ess/ess-trex.h5",
+        "hash": "md5:1eb645ec2e71324c2d03a30c4f3525fb",
+    },
+    "ess-heimdal": {
+        "path": "ess/ess-heimdal.h5",
+        "hash": "md5:e95da29df2f478eb7357583b8c388123",
+    },
+    "ess-dream": {
+        "path": "ess/ess-dream.h5",
+        "hash": "md5:0957767f7439f70aaf1abf934d30da07",
+    },
+    "ess-loki": {
+        "path": "ess/ess-loki.h5",
+        "hash": "md5:319936b29e3e8ac70283408950e6195c",
+    },
+    "ess-freia": {
+        "path": "ess/ess-freia.h5",
+        "hash": "md5:cad1a612214d0155b060094b1078f254",
+    },
+    "ess-estia": {
+        "path": "ess/ess-estia.h5",
+        "hash": "md5:a0bdf9e17611a77054686c5041aaae3f",
+    },
+    "ess-skadi": {
+        "path": "ess/ess-skadi.h5",
+        "hash": "md5:521dc300296db137fa3dd5877882f68c",
+    },
+    "ess-vespa": {
+        "path": "ess/ess-vespa.h5",
+        "hash": "md5:298f599f7dc861d1319748c7ea3c54fc",
+    },
+    "ess-tbl": {
+        "path": "ess/ess-tbl.h5",
+        "hash": "md5:c9db7f205131c4caf491d5951253bea7",
     },
 }
 

--- a/tests/facilities/source_library_test.py
+++ b/tests/facilities/source_library_test.py
@@ -4,7 +4,9 @@
 from pathlib import Path
 
 import pooch
+import pytest
 
+import tof
 from tof.facilities import _BASE_URLS, _source_library
 
 
@@ -29,3 +31,13 @@ def test_source_library_files_identical_on_public_and_github(tmp_path: Path) -> 
         p_public = Path(public.fetch(rel))
 
         assert p_gh.name == p_public.name
+
+
+@pytest.mark.parametrize("entry", _source_library.keys())
+def test_can_create_source_for_library_entry(entry) -> None:
+    source = tof.Source(facility=entry, neutrons=1000)
+    assert source.neutrons == 1000
+    assert "birth_time" in source.data.coords
+    assert "wavelength" in source.data.coords
+    assert source.frequency is not None
+    assert source.distance is not None

--- a/tests/facilities/source_library_test.py
+++ b/tests/facilities/source_library_test.py
@@ -7,11 +7,11 @@ import pooch
 import pytest
 
 import tof
-from tof.facilities import _BASE_URLS, _source_library
+from tof.facilities import _BASE_URLS, source_library
 
 
 def test_source_library_files_identical_on_public_and_github(tmp_path: Path) -> None:
-    registry = {f["path"]: f["hash"] for f in _source_library.values()}
+    registry = {f["path"]: f["hash"] for f in source_library.values()}
 
     public = pooch.create(
         path=tmp_path / "cache_public", base_url=_BASE_URLS[0], registry=registry
@@ -21,7 +21,7 @@ def test_source_library_files_identical_on_public_and_github(tmp_path: Path) -> 
         path=tmp_path / "cache_github", base_url=_BASE_URLS[1], registry=registry
     )
 
-    for entry in _source_library.values():
+    for entry in source_library.values():
         rel = entry["path"]
 
         # Verify that hashes are the same in both registries.
@@ -33,7 +33,7 @@ def test_source_library_files_identical_on_public_and_github(tmp_path: Path) -> 
         assert p_gh.name == p_public.name
 
 
-@pytest.mark.parametrize("entry", _source_library.keys())
+@pytest.mark.parametrize("entry", source_library.keys())
 def test_can_create_source_for_library_entry(entry) -> None:
     source = tof.Source(facility=entry, neutrons=1000)
     assert source.neutrons == 1000

--- a/tests/source_test.py
+++ b/tests/source_test.py
@@ -16,7 +16,7 @@ def test_ess_pulse():
     mean = times.mean()
     assert (times[0] < 0.5 * mean).value
     assert (times[-1] < 0.5 * mean).value
-    assert (times[150] > 1.5 * mean).value
+    assert (times['birth_time', sc.scalar(2000, unit='us')] > 1.5 * mean).value
     # Check that there are more neutrons at low wavelengths
     wavs = source.data['pulse', 0].hist(wavelength=300)
     assert (wavs[:150].sum() > 1.5 * wavs[150:].sum()).value

--- a/tools/generate-ess-sources.ipynb
+++ b/tools/generate-ess-sources.ipynb
@@ -1,0 +1,154 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Create ESS instrument sources"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import mcstasscript as ms\n",
+    "import scipp as sc\n",
+    "from scipy.ndimage import gaussian_filter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "beamports = {\n",
+    "    \"nmx\": \"W1\",\n",
+    "    \"beer\": \"W2\",\n",
+    "    \"cspec\": \"W3\",\n",
+    "    \"bifrost\": \"W4\",\n",
+    "    \"miracles\": \"W5\",\n",
+    "    \"magic\": \"W6\",\n",
+    "    \"trex\": \"W7\",\n",
+    "    \"heimdal\": \"W8\",\n",
+    "    \"odin\": \"S2\",\n",
+    "    \"dream\": \"S3\",\n",
+    "    \"loki\": \"N7\",\n",
+    "    \"freia\": \"N5\",\n",
+    "    \"estia\": \"E2\",\n",
+    "    \"skadi\": \"E3\",\n",
+    "    \"vespa\": \"E7\",\n",
+    "    \"tbl\": \"W11\",\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for instr, port in beamports.items():\n",
+    "\n",
+    "    print(\"Making source for\", instr, port)\n",
+    "\n",
+    "    instrument = ms.McStas_instr(\"source_check\")\n",
+    "\n",
+    "    source = instrument.add_component(\"Source\", \"ESS_butterfly\")\n",
+    "    # different spectra for each sector/beamport\n",
+    "    source.set_parameters(sector=f'\"{port[0]}\"', beamline=int(port[1]), n_pulses=1)\n",
+    "    source.tmax_multiplier = 3.0 # default 3, samples the tail out to 3 x 2.86 ms\n",
+    "    source.acc_power = 2 # accelerator power in MW\n",
+    "    source.set_parameters(Lmin=0.1, Lmax=20) # wavelength range\n",
+    "    # investigate rays that go to this place, 2 m in front, 10x10 cm area (distribution differs depending on direction)\n",
+    "    source.set_parameters(focus_xw=0.1, focus_yh=0.1, dist=2)\n",
+    "\n",
+    "    # monitor = instrument.add_component(\"surface_monitor\", \"Monitor_nD\")\n",
+    "    # monitor.set_parameters(options='\"previous, x y z vx vy vz l t list all neutrons\"', restore_neutron=1)\n",
+    "\n",
+    "    monitor = instrument.add_component(\"flat_monitor\", \"Monitor_nD\")\n",
+    "    monitor.set_parameters(xwidth=1.0, yheight=1.0, restore_neutron=1) # large flat monitor\n",
+    "    monitor.options=f'\"square, l bins=1024 limits=[{source.Lmin} {source.Lmax}] t bins=1024 limits=[0 {source.tmax_multiplier*2E-3}]\"'\n",
+    "    monitor.set_AT(0.05, RELATIVE=source)\n",
+    "\n",
+    "    instrument.settings(ncount=1.0e8, mpi=8)\n",
+    "\n",
+    "    data = instrument.backengine()\n",
+    "\n",
+    "    smooth = gaussian_filter(data[0].Intensity.T, sigma=2)\n",
+    "\n",
+    "    lims = data[0].metadata.limits\n",
+    "\n",
+    "    da = sc.DataArray(\n",
+    "        data = sc.array(dims=['wavelength', 'birth_time'], values=smooth/smooth.sum()),\n",
+    "        coords={\"birth_time\": sc.midpoints(sc.linspace('birth_time', lims[2], lims[3], smooth.shape[1] + 1, unit='s').to(unit='us')),\n",
+    "                \"wavelength\": sc.midpoints(sc.linspace('wavelength', lims[0], lims[1], smooth.shape[0] + 1, unit='angstrom')),\n",
+    "                \"frequency\": sc.scalar(14.0, unit=\"Hz\"),\n",
+    "                \"distance\": sc.scalar(0.05, unit=\"m\")}\n",
+    "    )\n",
+    "\n",
+    "    da.save_hdf5(f'ess-{instr}.h5')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4",
+   "metadata": {},
+   "source": [
+    "## Default ESS source\n",
+    "\n",
+    "To create the default ESS source, we simply take the mean profile across all instruments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_sources = sc.concat([sc.io.load_hdf5(f'ess-{instr}.h5') for instr in beamports], dim='instrument')\n",
+    "mean_source = all_sources.mean('instrument')\n",
+    "mean_source = mean_source / mean_source.sum()\n",
+    "mean_source.save_hdf5('ess.h5')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mean_source.plot()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Add sources generated with McStas notebook for all 16 instruments.
The new default ess source is created as the average of all sources.

The high-resolution binning will then enable us to use uniform noise during the sample instead of gaussian noise, which would fix issues in sampling optimization in #136 

We also add the notebook that was used to generate the sources. It is not ran as part of the docs, as it is too expensive to run in CI.


Updated default ESS source profile:
<img width="600" height="400" alt="Figure 1 (45)" src="https://github.com/user-attachments/assets/3f21be0c-73a0-42dd-999a-b0ef59c4a327" />

<img width="600" height="400" alt="Figure 1 (46)" src="https://github.com/user-attachments/assets/b66399e3-3b49-44e0-8dd1-1a49e1a92f84" />
