### PR TITLE
Allow 0 frequency choppers

### DIFF
--- a/src/tof/chopper.py
+++ b/src/tof/chopper.py
@@ -143,7 +143,7 @@ class Chopper(Component):
         direction: Direction = Clockwise,
     ):
         if frequency < (0.0 * frequency.unit):
-            raise ValueError(f"Chopper frequency must be positive, got {frequency:c}.")
+            raise ValueError(f"Chopper frequency must be non-negative, got {frequency:c}.")
         self.frequency = frequency.to(dtype=float, copy=False)
         if direction not in (Clockwise, AntiClockwise):
             raise ValueError(

--- a/src/tof/chopper.py
+++ b/src/tof/chopper.py
@@ -142,7 +142,7 @@ class Chopper(Component):
         widths: sc.Variable | None = None,
         direction: Direction = Clockwise,
     ):
-        if frequency <= (0.0 * frequency.unit):
+        if frequency < (0.0 * frequency.unit):
             raise ValueError(f"Chopper frequency must be positive, got {frequency:c}.")
         self.frequency = frequency.to(dtype=float, copy=False)
         if direction not in (Clockwise, AntiClockwise):
@@ -208,6 +208,13 @@ class Chopper(Component):
             time_limit = sc.scalar(0.0, unit='us')
         if unit is None:
             unit = time_limit.unit
+
+        if self.frequency.value == 0.0:
+            return (
+                sc.array(dims=['cutout'], values=[-np.inf], unit=unit),
+                sc.array(dims=['cutout'], values=[np.inf], unit=unit),
+            )
+
         nrot = max(int(sc.ceil((time_limit * self.frequency).to(unit='')).value), 1)
         # We make a unique dim name that is different from self.open.dim and
         # self.close.dim to make use of automatic broadcasting below.

--- a/src/tof/chopper.py
+++ b/src/tof/chopper.py
@@ -143,7 +143,9 @@ class Chopper(Component):
         direction: Direction = Clockwise,
     ):
         if frequency < (0.0 * frequency.unit):
-            raise ValueError(f"Chopper frequency must be non-negative, got {frequency:c}.")
+            raise ValueError(
+                f"Chopper frequency must be non-negative, got {frequency:c}."
+            )
         self.frequency = frequency.to(dtype=float, copy=False)
         if direction not in (Clockwise, AntiClockwise):
             raise ValueError(

--- a/tests/chopper_test.py
+++ b/tests/chopper_test.py
@@ -688,3 +688,17 @@ def test_from_nexus_clockwise():
         nexus_chopper['slit_edges'][1::2] - nexus_chopper['beam_position'],
     )
     assert chopper.direction == tof.Clockwise
+
+
+def test_chopper_zero_frequency():
+    chopper = tof.Chopper(
+        frequency=0.0 * Hz,
+        open=10.0 * deg,
+        close=20.0 * deg,
+        phase=0.0 * deg,
+        distance=5.0 * meter,
+        name='chopper',
+    )
+    topen, tclose = chopper.open_close_times(0.0 * sec)
+    assert sc.identical(topen[0], -np.inf * sec)
+    assert sc.identical(tclose[0], np.inf * sec)

--- a/tests/chopper_test.py
+++ b/tests/chopper_test.py
@@ -149,7 +149,7 @@ def test_phase_int():
 
 
 def test_frequency_must_be_positive():
-    with pytest.raises(ValueError, match="Chopper frequency must be positive"):
+    with pytest.raises(ValueError, match="Chopper frequency must be non-negative"):
         tof.Chopper(
             frequency=-1.0 * Hz,
             open=0.0 * deg,

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -697,3 +697,28 @@ def test_model_run_without_components_raises(dummy_source):
         ValueError, match="Cannot run model: no components have been defined."
     ):
         model.run()
+
+
+def test_chopper_with_zero_frequency_blocks_nothing(make_source):
+    chopper = tof.Chopper(
+        frequency=0.0 * Hz,
+        open=10.0 * deg,
+        close=20.0 * deg,
+        phase=0.0 * deg,
+        distance=5.0 * meter,
+        name='chopper',
+    )
+    detector = tof.Detector(distance=20 * meter, name='detector')
+
+    N = 10_000
+
+    source = tof.Source(facility='ess', neutrons=N)
+    model = tof.Model(source=source, choppers=[chopper], detectors=[detector])
+    res = model.run()
+
+    assert res.choppers['chopper'].toa.data.sum().value == N
+    assert res.choppers['chopper'].toa.data.masks['blocked_by_me'].sum().value == 0
+    assert res.detectors['detector'].toa.data.sum().value == N
+    assert (
+        res.detectors['detector'].toa.data.masks['blocked_by_others'].sum().value == 0
+    )


### PR DESCRIPTION
Before these changes, creating a chopper which is parked with 0 frequency
```Py
tof.Chopper(
    frequency=0 * Hz,
    open=sc.array(dims=['cutout'], values=[30.0], unit='deg'),
    close=sc.array(dims=['cutout'], values=[140.0], unit='deg'),
    phase=0 * deg,
    distance=22 * meter,
    name="Pulse-overlap",
)
```
raised `Chopper frequency must be positive`.

Now, this is allowed. The `chopper.open_close_times()` returns and infinite range `[-np.inf, np.inf]`, and the chopper blocks no neutrons.