### PR TITLE
Remove links to the jupyterlite version of the dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,8 @@
 [![PyPI badge](http://img.shields.io/pypi/v/tof.svg)](https://pypi.python.org/pypi/tof)
 [![Anaconda-Server Badge](https://anaconda.org/conda-forge/tof/badges/version.svg)](https://anaconda.org/conda-forge/tof)
 [![License: BSD 3-Clause](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](LICENSE)
-[![Try it](https://img.shields.io/badge/try_it_in_your_browser!-8A2BE2)](https://scipp.github.io/toflite/lab/index.html?path=app.ipynb)
 
 # Tof
-
 
 ## About
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,9 +28,6 @@
   </br></br>
 </div>
 
-## ✨ [Try it in your browser](https://scipp.github.io/toflite/lab/index.html?path=app.ipynb) ✨
-
-
 ## Installation
 
 To install Tof and all of its dependencies, use


### PR DESCRIPTION
The JupyterLite version of the dashboard is currently broken with this error:
<img width="762" height="117" alt="Screenshot_20260603_160929" src="https://github.com/user-attachments/assets/c6282ec9-fdab-49f7-bc3f-cb72a3ef8742" />

That dashboard is also a large maintenance burden that we will not support further.