### PR TITLE
Fix chopper rotations in optimize_for and Chopper

### DIFF
--- a/src/tof/chopper.py
+++ b/src/tof/chopper.py
@@ -254,6 +254,9 @@ class Chopper(Component):
         # We find the smallest open or close angle (they may be negative and lower than
         # -360 degrees), and compute how many rotations it would take for that angle to
         # each the time limit.
+        #
+        # Note: we do this AFTER we have mirrored the angles for anti-clockwise
+        # choppers, so that the phase is applied in the correct direction.
         largest_angle = max(open_times.max(), close_times.max()) + phase
         rot_start = (largest_angle - self.omega * sc.scalar(0.0, unit='s')) / two_pi
         rot_start = -max(int(sc.ceil(rot_start).value), 1)

--- a/src/tof/chopper.py
+++ b/src/tof/chopper.py
@@ -223,21 +223,10 @@ class Chopper(Component):
         # each the time limit.
         # We always add one extra rotation for edge cases and coincidences.
         smallest_angle = min(self.open.min(), self.close.min())
-        nrot = (
-            max(
-                int(
-                    sc.ceil(
-                        (
-                            self.omega * time_limit.to(unit='s')
-                            - smallest_angle.to(unit='rad')
-                        )
-                        / two_pi
-                    ).value
-                ),
-                1,
-            )
-            + 1
-        )
+        rotations = (
+            self.omega * time_limit.to(unit='s') - smallest_angle.to(unit='rad')
+        ) / two_pi
+        nrot = max(int(sc.ceil(rotations).value), 1) + 1
         # We make a unique dim name that is different from self.open.dim and
         # self.close.dim to make use of automatic broadcasting below.
         # We also start at -1 to catch early openings in case the phase or opening

--- a/src/tof/chopper.py
+++ b/src/tof/chopper.py
@@ -217,7 +217,27 @@ class Chopper(Component):
                 sc.array(dims=['cutout'], values=[np.inf], unit=unit),
             )
 
-        nrot = max(int(sc.ceil((time_limit * self.frequency).to(unit='')).value), 1)
+        # Predicting how many rotations are needed to reach the time limit:
+        # We find the smallest open or close angle (they may be negative and lower than
+        # -360 degrees), and compute how many rotations it would take for that angle to
+        # each the time limit.
+        # We always add one extra rotation for edge cases and coincidences.
+        smallest_angle = min(self.open.min(), self.close.min())
+        nrot = (
+            max(
+                int(
+                    sc.ceil(
+                        (
+                            self.omega * time_limit.to(unit='s')
+                            - smallest_angle.to(unit='rad')
+                        )
+                        / two_pi
+                    ).value
+                ),
+                1,
+            )
+            + 1
+        )
         # We make a unique dim name that is different from self.open.dim and
         # self.close.dim to make use of automatic broadcasting below.
         # We also start at -1 to catch early openings in case the phase or opening

--- a/src/tof/chopper.py
+++ b/src/tof/chopper.py
@@ -175,6 +175,11 @@ class Chopper(Component):
         self.close = (close if close.dims else close.flatten(to='cutout')).to(
             dtype=float, copy=False
         )
+        if not all(self.open < self.close):
+            raise ValueError(
+                "Chopper open angles must be less than close angles, "
+                f"got open={self.open}, close={self.close}."
+            )
         self.distance = distance.to(dtype=float, copy=False)
         self.phase = phase.to(dtype=float, copy=False)
         self.name = name
@@ -217,24 +222,6 @@ class Chopper(Component):
                 sc.array(dims=['cutout'], values=[np.inf], unit=unit),
             )
 
-        # Predicting how many rotations are needed to reach the time limit:
-        # We find the smallest open or close angle (they may be negative and lower than
-        # -360 degrees), and compute how many rotations it would take for that angle to
-        # each the time limit.
-        # We always add one extra rotation for edge cases and coincidences.
-        smallest_angle = min(self.open.min(), self.close.min())
-        rotations = (
-            self.omega * time_limit.to(unit='s') - smallest_angle.to(unit='rad')
-        ) / two_pi
-        nrot = max(int(sc.ceil(rotations).value), 1) + 1
-        # We make a unique dim name that is different from self.open.dim and
-        # self.close.dim to make use of automatic broadcasting below.
-        # We also start at -1 to catch early openings in case the phase or opening
-        # angles are large
-        phases = sc.arange(
-            f"{self.open.dim}-{self.close.dim}", -1, nrot
-        ) * two_pi + self.phase.to(unit='rad')
-
         open_times = self.open.to(unit='rad', copy=False)
         close_times = self.close.to(unit='rad', copy=False)
         # If the chopper is rotating anti-clockwise, we mirror the openings because the
@@ -252,6 +239,36 @@ class Chopper(Component):
                     unit=open_times.unit,
                 ),
             )
+
+        phase = self.phase.to(unit='rad')
+
+        # Predicting how many rotations are needed to cover the time range between
+        # 0 and the time limit:
+        #
+        # Start: t=0
+        # We find the largest open or close angle (they may be negative or larger than
+        # 360 degrees), and compute how many backward rotations it would take for that
+        # angle to pass t=0.
+        #
+        # End:
+        # We find the smallest open or close angle (they may be negative and lower than
+        # -360 degrees), and compute how many rotations it would take for that angle to
+        # each the time limit.
+        largest_angle = max(open_times.max(), close_times.max()) + phase
+        rot_start = (largest_angle - self.omega * sc.scalar(0.0, unit='s')) / two_pi
+        rot_start = -max(int(sc.ceil(rot_start).value), 1)
+
+        smallest_angle = min(open_times.min(), close_times.min()) + phase
+        rot_end = (self.omega * time_limit.to(unit='s') - smallest_angle) / two_pi
+        # Need +1 for arange upper bound
+        rot_end = max(int(sc.ceil(rot_end).value), 1) + 1
+
+        # We make a unique dim name that is different from self.open.dim and
+        # self.close.dim to make use of automatic broadcasting below.
+        phases = sc.arange(
+            f"{self.open.dim}-{self.close.dim}", rot_start, rot_end
+        ) * two_pi + self.phase.to(unit='rad')
+
         # Note that the order is important here: we need (phases + open/close) to get
         # the correct dimension order when we flatten.
         open_times = (phases + open_times).flatten(to=self.open.dim)

--- a/src/tof/optimization.py
+++ b/src/tof/optimization.py
@@ -138,8 +138,6 @@ class Frame:
         frame = self.propagate_to(distance)
 
         timescale = max(sf.time.max() for sf in frame.subframes)
-        print("timescale", timescale, chopper.name)
-        timescale = sc.scalar(3.0, unit='s')
 
         # A chopper can have multiple openings, call _chop for each of them. The result
         # is the union of the resulting subframes.
@@ -147,8 +145,6 @@ class Frame:
         open_times, close_times = (
             t.to(unit='s') for t in chopper.open_close_times(timescale)
         )
-        print("open_times", open_times)
-        print("close_times", close_times)
         for subframe in frame.subframes:
             for open, close in zip(open_times, close_times, strict=True):
                 if (tmp := _chop(subframe, open, close_to_open=True)) is not None:

--- a/src/tof/optimization.py
+++ b/src/tof/optimization.py
@@ -137,10 +137,18 @@ class Frame:
             )
         frame = self.propagate_to(distance)
 
+        timescale = max(sf.time.max() for sf in frame.subframes)
+        print("timescale", timescale, chopper.name)
+        timescale = sc.scalar(3.0, unit='s')
+
         # A chopper can have multiple openings, call _chop for each of them. The result
         # is the union of the resulting subframes.
         chopped = Frame(distance=frame.distance, subframes=[])
-        open_times, close_times = (t.to(unit='s') for t in chopper.open_close_times())
+        open_times, close_times = (
+            t.to(unit='s') for t in chopper.open_close_times(timescale)
+        )
+        print("open_times", open_times)
+        print("close_times", close_times)
         for subframe in frame.subframes:
             for open, close in zip(open_times, close_times, strict=True):
                 if (tmp := _chop(subframe, open, close_to_open=True)) is not None:

--- a/tests/chopper_test.py
+++ b/tests/chopper_test.py
@@ -246,7 +246,7 @@ def test_open_close_anticlockwise_multiple_rotations():
         name='chopper',
     )
 
-    # By default, the chopper perfoms 3 rotations: one before t=0, one at t=0, and one
+    # By default, the chopper performs 3 rotations: one before t=0, one at t=0, and one
     # after t=0. The number of rotations is determined by the time limit.
     three_rotations_open, three_rotations_close = chopper.open_close_times(0.0 * sec)
     four_rotations_open, four_rotations_close = chopper.open_close_times(0.2 * sec)

--- a/tests/chopper_test.py
+++ b/tests/chopper_test.py
@@ -68,14 +68,27 @@ def test_open_close_times_three_rotations():
     assert sc.identical(
         topen,
         sc.concat(
-            [open0 - two_pi, open0, open0 + two_pi, open0 + 2 * two_pi], dim='cutout'
+            [
+                open0 - two_pi,  # rotation -1 (before t=0)
+                open0,  # rotation 0
+                open0 + two_pi,  # rotation 1
+                open0 + 2 * two_pi,  # rotation 2
+                open0 + 3 * two_pi,  # rotation 3 (one more rotation after t=0.21 s)
+            ],
+            dim='cutout',
         )
         / (two_pi * f),
     )
     assert sc.identical(
         tclose,
         sc.concat(
-            [close0 - two_pi, close0, close0 + two_pi, close0 + 2 * two_pi],
+            [
+                close0 - two_pi,  # rotation -1 (before t=0)
+                close0,  # rotation 0
+                close0 + two_pi,  # rotation 1
+                close0 + 2 * two_pi,  # rotation 2
+                close0 + 3 * two_pi,  # rotation 3 (one more rotation after t=0.21 s)
+            ],
             dim='cutout',
         )
         / (two_pi * f),
@@ -233,23 +246,25 @@ def test_open_close_anticlockwise_multiple_rotations():
         name='chopper',
     )
 
-    two_rotations_open, two_rotations_close = chopper.open_close_times(0.0 * sec)
-    three_rotations_open, three_rotations_close = chopper.open_close_times(0.2 * sec)
-    four_rotations_open, four_rotations_close = chopper.open_close_times(0.3 * sec)
+    # By default, the chopper perfoms 3 rotations: one before t=0, one at t=0, and one
+    # after t=0. The number of rotations is determined by the time limit.
+    three_rotations_open, three_rotations_close = chopper.open_close_times(0.0 * sec)
+    four_rotations_open, four_rotations_close = chopper.open_close_times(0.2 * sec)
+    five_rotations_open, five_rotations_close = chopper.open_close_times(0.3 * sec)
 
-    assert len(two_rotations_open) == 4
     assert len(three_rotations_open) == 6
     assert len(four_rotations_open) == 8
-    assert len(two_rotations_close) == 4
+    assert len(five_rotations_open) == 10
     assert len(three_rotations_close) == 6
     assert len(four_rotations_close) == 8
+    assert len(five_rotations_close) == 10
 
-    assert sc.allclose(two_rotations_open, three_rotations_open[:-2])
-    assert sc.allclose(two_rotations_close, three_rotations_close[:-2])
     assert sc.allclose(three_rotations_open, four_rotations_open[:-2])
     assert sc.allclose(three_rotations_close, four_rotations_close[:-2])
-    assert sc.allclose(two_rotations_open, four_rotations_open[:-4])
-    assert sc.allclose(two_rotations_close, four_rotations_close[:-4])
+    assert sc.allclose(three_rotations_open, four_rotations_open[:-2])
+    assert sc.allclose(three_rotations_close, four_rotations_close[:-2])
+    assert sc.allclose(three_rotations_open, five_rotations_open[:-4])
+    assert sc.allclose(three_rotations_close, five_rotations_close[:-4])
 
 
 def test_bad_direction_raises():
@@ -702,3 +717,85 @@ def test_chopper_zero_frequency():
     topen, tclose = chopper.open_close_times(0.0 * sec)
     assert sc.identical(topen[0], -np.inf * sec)
     assert sc.identical(tclose[0], np.inf * sec)
+
+
+@pytest.mark.parametrize("direction", [tof.Clockwise, tof.AntiClockwise])
+def test_chopper_performs_enough_rotations_to_cover_timescale(direction):
+    chopper = tof.Chopper(
+        frequency=14.0 * Hz,
+        open=10.0 * deg,
+        close=20.0 * deg,
+        phase=0.0 * deg,
+        distance=5.0 * meter,
+        name='chopper',
+        direction=direction,
+    )
+    timescale = 2.0 * sec
+    topen, tclose = chopper.open_close_times(timescale)
+    assert (topen[-1] >= timescale).value
+    assert (tclose[-1] >= timescale).value
+
+
+@pytest.mark.parametrize("direction", [tof.Clockwise, tof.AntiClockwise])
+def test_chopper_with_negative_angles_performs_enough_rotations_to_cover_timescale(
+    direction,
+):
+    chopper = tof.Chopper(
+        frequency=14.0 * Hz,
+        open=sc.array(dims=['cutout'], values=[-350.0, -10.0], unit='deg'),
+        close=sc.array(dims=['cutout'], values=[-340.0, 0.0], unit='deg'),
+        phase=0.0 * deg,
+        distance=5.0 * meter,
+        name='chopper',
+        direction=direction,
+    )
+    timescale = 2.0 * sec
+    topen, tclose = chopper.open_close_times(timescale)
+    assert (topen[-1] >= timescale).value
+    assert (tclose[-1] >= timescale).value
+
+
+@pytest.mark.parametrize("direction", [tof.Clockwise, tof.AntiClockwise])
+def test_chopper_with_very_negative_angles_performs_enough_rotations_to_cover_timescale(
+    direction,
+):
+    chopper = tof.Chopper(
+        frequency=14.0 * Hz,
+        open=sc.array(dims=['cutout'], values=[-710.0, -370.0], unit='deg'),
+        close=sc.array(dims=['cutout'], values=[-700.0, -360.0], unit='deg'),
+        phase=0.0 * deg,
+        distance=5.0 * meter,
+        name='chopper',
+        direction=direction,
+    )
+    timescale = 1.5 * sec
+    topen, tclose = chopper.open_close_times(timescale)
+    assert (topen[-1] >= timescale).value
+    assert (tclose[-1] >= timescale).value
+
+
+@pytest.mark.parametrize("direction", [tof.Clockwise, tof.AntiClockwise])
+def test_chopper_with_more_negative_angles_perfoms_more_rotations(direction):
+    chop1 = tof.Chopper(
+        frequency=14.0 * Hz,
+        open=sc.array(dims=['cutout'], values=[-450.0], unit='deg'),
+        close=sc.array(dims=['cutout'], values=[-440.0], unit='deg'),
+        phase=0.0 * deg,
+        distance=5.0 * meter,
+        name='chopper1',
+        direction=direction,
+    )
+    chop2 = tof.Chopper(
+        frequency=14.0 * Hz,
+        open=sc.array(dims=['cutout'], values=[-50.0], unit='deg'),
+        close=sc.array(dims=['cutout'], values=[-40.0], unit='deg'),
+        phase=0.0 * deg,
+        distance=5.0 * meter,
+        name='chopper2',
+        direction=direction,
+    )
+    timescale = 1.5 * sec
+    topen1, tclose1 = chop1.open_close_times(timescale)
+    topen2, tclose2 = chop2.open_close_times(timescale)
+    assert len(topen1) > len(topen2)
+    assert len(tclose1) > len(tclose2)

--- a/tests/chopper_test.py
+++ b/tests/chopper_test.py
@@ -372,6 +372,21 @@ def test_chopper_create_raises_when_both_edges_and_centers_are_supplied():
         )
 
 
+def test_chopper_create_raises_when_open_angles_are_larger_than_close_angles():
+    with pytest.raises(
+        ValueError,
+        match="Chopper open angles must be less than close angles",
+    ):
+        tof.Chopper(
+            frequency=10.0 * Hz,
+            open=sc.array(dims=['cutout'], values=[10.0, 50.0], unit='deg'),
+            close=sc.array(dims=['cutout'], values=[20.0, 40.0], unit='deg'),
+            phase=0.0 * deg,
+            distance=5.0 * meter,
+            name='chopper',
+        )
+
+
 def test_as_json():
     f = 10.0 * Hz
     chopper = tof.Chopper(
@@ -720,82 +735,82 @@ def test_chopper_zero_frequency():
 
 
 @pytest.mark.parametrize("direction", [tof.Clockwise, tof.AntiClockwise])
-def test_chopper_performs_enough_rotations_to_cover_timescale(direction):
+@pytest.mark.parametrize("phase", [-350, -270, -190, -30, 0, 30, 190, 270, 350])
+def test_chopper_performs_enough_rotations_to_cover_timescale(direction, phase):
     chopper = tof.Chopper(
         frequency=14.0 * Hz,
         open=10.0 * deg,
         close=20.0 * deg,
-        phase=0.0 * deg,
+        phase=phase * deg,
         distance=5.0 * meter,
         name='chopper',
         direction=direction,
     )
     timescale = 2.0 * sec
+    zero = 0.0 * sec
     topen, tclose = chopper.open_close_times(timescale)
-    assert (topen[-1] >= timescale).value
-    assert (tclose[-1] >= timescale).value
+    assert (topen.min() <= zero).value
+    assert (tclose.max() >= timescale).value
 
 
 @pytest.mark.parametrize("direction", [tof.Clockwise, tof.AntiClockwise])
+@pytest.mark.parametrize("phase", [-350, -270, -190, -30, 0, 30, 190, 270, 350])
 def test_chopper_with_negative_angles_performs_enough_rotations_to_cover_timescale(
-    direction,
+    direction, phase
 ):
     chopper = tof.Chopper(
         frequency=14.0 * Hz,
         open=sc.array(dims=['cutout'], values=[-350.0, -10.0], unit='deg'),
         close=sc.array(dims=['cutout'], values=[-340.0, 0.0], unit='deg'),
-        phase=0.0 * deg,
+        phase=phase * deg,
         distance=5.0 * meter,
         name='chopper',
         direction=direction,
     )
     timescale = 2.0 * sec
+    zero = 0.0 * sec
     topen, tclose = chopper.open_close_times(timescale)
-    assert (topen[-1] >= timescale).value
-    assert (tclose[-1] >= timescale).value
+    assert (topen.min() <= zero).value
+    assert (tclose.max() >= timescale).value
 
 
 @pytest.mark.parametrize("direction", [tof.Clockwise, tof.AntiClockwise])
+@pytest.mark.parametrize("phase", [-350, -270, -190, -30, 0, 30, 190, 270, 350])
 def test_chopper_with_very_negative_angles_performs_enough_rotations_to_cover_timescale(
-    direction,
+    direction, phase
 ):
     chopper = tof.Chopper(
         frequency=14.0 * Hz,
         open=sc.array(dims=['cutout'], values=[-710.0, -370.0], unit='deg'),
         close=sc.array(dims=['cutout'], values=[-700.0, -360.0], unit='deg'),
-        phase=0.0 * deg,
+        phase=phase * deg,
         distance=5.0 * meter,
         name='chopper',
         direction=direction,
     )
     timescale = 1.5 * sec
+    zero = 0.0 * sec
     topen, tclose = chopper.open_close_times(timescale)
-    assert (topen[-1] >= timescale).value
-    assert (tclose[-1] >= timescale).value
+    assert (topen.min() <= zero).value
+    assert (tclose.max() >= timescale).value
 
 
 @pytest.mark.parametrize("direction", [tof.Clockwise, tof.AntiClockwise])
-def test_chopper_with_more_negative_angles_perfoms_more_rotations(direction):
-    chop1 = tof.Chopper(
+@pytest.mark.parametrize("phase", [-350, -270, -190, -30, 0, 30, 190, 270, 350])
+def test_chopper_with_very_positive_angles_performs_enough_rotations_to_cover_timescale(
+    direction, phase
+):
+    chopper = tof.Chopper(
         frequency=14.0 * Hz,
-        open=sc.array(dims=['cutout'], values=[-450.0], unit='deg'),
-        close=sc.array(dims=['cutout'], values=[-440.0], unit='deg'),
-        phase=0.0 * deg,
+        open=sc.array(dims=['cutout'], values=[400.0, 620.0], unit='deg'),
+        close=sc.array(dims=['cutout'], values=[410.0, 640.0], unit='deg'),
+        phase=phase * deg,
         distance=5.0 * meter,
-        name='chopper1',
-        direction=direction,
-    )
-    chop2 = tof.Chopper(
-        frequency=14.0 * Hz,
-        open=sc.array(dims=['cutout'], values=[-50.0], unit='deg'),
-        close=sc.array(dims=['cutout'], values=[-40.0], unit='deg'),
-        phase=0.0 * deg,
-        distance=5.0 * meter,
-        name='chopper2',
+        name='chopper',
         direction=direction,
     )
     timescale = 1.5 * sec
-    topen1, tclose1 = chop1.open_close_times(timescale)
-    topen2, tclose2 = chop2.open_close_times(timescale)
-    assert len(topen1) > len(topen2)
-    assert len(tclose1) > len(tclose2)
+    zero = 0.0 * sec
+    topen, tclose = chopper.open_close_times(timescale)
+    assert (topen.min() <= zero).value
+    assert (tclose.max() >= timescale).value

--- a/tests/chopper_test.py
+++ b/tests/chopper_test.py
@@ -734,8 +734,11 @@ def test_chopper_zero_frequency():
     assert sc.identical(tclose[0], np.inf * sec)
 
 
+PHASES = [-500, -350, -270, -190, -30, 0, 30, 190, 270, 350, 500]
+
+
 @pytest.mark.parametrize("direction", [tof.Clockwise, tof.AntiClockwise])
-@pytest.mark.parametrize("phase", [-350, -270, -190, -30, 0, 30, 190, 270, 350])
+@pytest.mark.parametrize("phase", PHASES)
 def test_chopper_performs_enough_rotations_to_cover_timescale(direction, phase):
     chopper = tof.Chopper(
         frequency=14.0 * Hz,
@@ -754,7 +757,7 @@ def test_chopper_performs_enough_rotations_to_cover_timescale(direction, phase):
 
 
 @pytest.mark.parametrize("direction", [tof.Clockwise, tof.AntiClockwise])
-@pytest.mark.parametrize("phase", [-350, -270, -190, -30, 0, 30, 190, 270, 350])
+@pytest.mark.parametrize("phase", PHASES)
 def test_chopper_with_negative_angles_performs_enough_rotations_to_cover_timescale(
     direction, phase
 ):
@@ -775,7 +778,7 @@ def test_chopper_with_negative_angles_performs_enough_rotations_to_cover_timesca
 
 
 @pytest.mark.parametrize("direction", [tof.Clockwise, tof.AntiClockwise])
-@pytest.mark.parametrize("phase", [-350, -270, -190, -30, 0, 30, 190, 270, 350])
+@pytest.mark.parametrize("phase", PHASES)
 def test_chopper_with_very_negative_angles_performs_enough_rotations_to_cover_timescale(
     direction, phase
 ):
@@ -796,7 +799,7 @@ def test_chopper_with_very_negative_angles_performs_enough_rotations_to_cover_ti
 
 
 @pytest.mark.parametrize("direction", [tof.Clockwise, tof.AntiClockwise])
-@pytest.mark.parametrize("phase", [-350, -270, -190, -30, 0, 30, 190, 270, 350])
+@pytest.mark.parametrize("phase", PHASES)
 def test_chopper_with_very_positive_angles_performs_enough_rotations_to_cover_timescale(
     direction, phase
 ):


### PR DESCRIPTION
When trying to use `optimize_for` in the Trex instrument case, no neutrons were making it through.
The pulse-shaping and monochromatic choppers were not performing enough rotations and were thus blocking all neutrons.
Giving them a timescale to dictate how long they should rotate for helped (in this PR also), but did not fix everything.
The pulse-shaping chopper 2 was still not performing enough rotations.

It was because it has some cutout angles < -360 deg, meaning that it was still missing at least one rotation to cover the requested timescale.
Instead of guessing from the rotation frequency and timescale alone, we now find the smallest cutout angle and compute how many rotations need to be done to reach the requested timescale.

We can now make a T-rex model, optimized for the choppers in the beamline, with 0 blocked neutrons:
<img width="1083" height="771" alt="Screenshot_20260623_135055" src="https://github.com/user-attachments/assets/aa74dedf-fbb3-4a00-8fc2-44da6074dd1c" />
<img width="600" height="400" alt="Figure 1 (17)" src="https://github.com/user-attachments/assets/2a110998-700a-4fbe-a38c-484c40f8a9b9" />

@bingli621 